### PR TITLE
Fixed role converter not converting a role mention

### DIFF
--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -292,7 +292,7 @@ async def role_converter(arg: WrappedArg) -> hikari.Role:
         :obj:`~.errors.ConverterFailure`: If the argument could not be resolved into a role object.
     """
     try:
-        role_id = _resolve_id_from_arg(arg.data, CHANNEL_MENTION_REGEX)
+        role_id = _resolve_id_from_arg(arg.data, ROLE_MENTION_REGEX)
     except ValueError:
         roles = arg.context.bot.cache.get_roles_view_for_guild(arg.context.guild_id)
         role = utils.get(roles.values(), name=arg.data)


### PR DESCRIPTION
### Summary
Fixes the role converter not converting a role mention (would raise a `ConverterFailure` instead)

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
#28 
