### PR TITLE
Changed app to bot in LightbulbEvent

### DIFF
--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -705,7 +705,7 @@ class Bot(hikari.BotApp):
         command: typing.Optional[commands.Command] = None,
     ) -> None:
         error_event = events.CommandErrorEvent(
-            app=self, exception=exception, message=message, context=context, command=command
+            bot=self, exception=exception, message=message, context=context, command=command
         )
 
         handled = False
@@ -849,7 +849,7 @@ class Bot(hikari.BotApp):
 
         context = self.get_context(event.message, prefix, invoked_with, command)
 
-        await self.dispatch(events.CommandInvocationEvent(app=self, command=command, context=context))
+        await self.dispatch(events.CommandInvocationEvent(bot=self, command=command, context=context))
         if (before_invoke := command._before_invoke) is not None:
             await before_invoke(context)
 
@@ -878,7 +878,7 @@ class Bot(hikari.BotApp):
         if (after_invoke := command._after_invoke) is not None:
             await after_invoke(context)
 
-        await self.dispatch(events.CommandCompletionEvent(app=self, command=command, context=context))
+        await self.dispatch(events.CommandCompletionEvent(bot=self, command=command, context=context))
 
     async def handle(self, event: hikari.MessageCreateEvent) -> None:
         """

--- a/lightbulb/events.py
+++ b/lightbulb/events.py
@@ -29,6 +29,7 @@ from hikari.events import base_events as hikari_base_events
 if typing.TYPE_CHECKING:
     import types
 
+    from lightbulb import command_handler
     from lightbulb import commands
     from lightbulb import context as context_
     from lightbulb import errors
@@ -42,8 +43,8 @@ class LightbulbEvent(hikari.Event, abc.ABC):
     will be an instance of a subclass of this.
     """
 
-    app: hikari.BotAware = attr.ib()
-    """App instance for this application."""
+    bot: command_handler.Bot = attr.ib()
+    """Bot instance for this event."""
 
 
 @attr.s(kw_only=True, slots=True, weakref_slot=False)


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->
Type changed from `hikari.BotAware` to `lightbulb.Bot`. This makes more
sense since it allows user to make use of the extended APIs lightbulb
exposes.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
