### PR TITLE
Pass remainder to the var pos arg and add more CommandSyntaxError errors

### DIFF
--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -471,12 +471,15 @@ class Command:
             try:
                 new_arg = await self.handle_types(arg, details.annotation)
                 new_args.append(new_arg)
-            except (errors.ConverterFailure, ValueError):
+            except (errors.ConverterFailure, ValueError) as exc:
                 _LOGGER.error(
                     "Failed converting %s with converter: %s",
                     arg,
                     getattr(details.annotation, "__name__", repr(details.annotation)),
                 )
+                if isinstance(exc, errors.ConverterFailure) and exc.text:
+                    raise  # don't override the preset text
+
                 raise errors.ConverterFailure(
                     text=f"Failed converting {arg} with converter: {getattr(details.annotation, '__name__', repr(details.annotation))}"
                 )

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -474,6 +474,10 @@ class Command:
                 raise errors.ConverterFailure(
                     text=f"Failed converting {arg} with converter: {getattr(details.annotation, '__name__', repr(details.annotation))}"
                 )
+
+        if self.arg_details.has_var_positional:
+            new_args.extend(args[len(new_args) :])
+
         return new_args
 
     async def invoke(self, context: context_.Context, *args: str, **kwargs: str) -> typing.Any:

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -31,6 +31,7 @@ import functools
 import inspect
 import logging
 import typing
+from itertools import zip_longest
 
 import hikari
 from multidict import CIMultiDict
@@ -40,7 +41,7 @@ from lightbulb import converters
 from lightbulb import cooldowns
 from lightbulb import errors
 from lightbulb import events
-from lightbulb.utils import maybe_await
+from lightbulb.utils import maybe_await, get
 
 if typing.TYPE_CHECKING:
     from lightbulb import plugins
@@ -75,7 +76,10 @@ def _bind_prototype(instance: typing.Any, command_template: _CommandT):
             if self.cooldown_manager is not None:
                 self.cooldown_manager.add_cooldown(context)
             # Add the start slice on to the length to offset the section of arg_details being extracted
-            new_args = await self._convert_args(context, args, list(self.arg_details.args.values())[2 : len(args) + 2])
+            arg_details = list(self.arg_details.args.values())[2 : len(args) + 2]
+            new_args = await self._convert_args(
+                context, args if self.arg_details.has_var_positional else args[: len(arg_details)], arg_details
+            )
 
             if kwargs:
                 new_kwarg = (
@@ -457,7 +461,9 @@ class Command:
     ) -> typing.Sequence[typing.Any]:
         new_args = []
 
-        for arg, details in zip(args, arg_details):
+        for arg, details in zip_longest(
+            args, arg_details, fillvalue=get(arg_details, argtype=inspect.Parameter.VAR_POSITIONAL)
+        ):
             arg = converters.WrappedArg(arg, context)
             if details.annotation is inspect.Parameter.empty or isinstance(details.annotation, str):
                 new_args.append(str(arg))
@@ -474,10 +480,6 @@ class Command:
                 raise errors.ConverterFailure(
                     text=f"Failed converting {arg} with converter: {getattr(details.annotation, '__name__', repr(details.annotation))}"
                 )
-
-        if self.arg_details.has_var_positional:
-            new_args.extend(args[len(new_args) :])
-
         return new_args
 
     async def invoke(self, context: context_.Context, *args: str, **kwargs: str) -> typing.Any:
@@ -497,8 +499,9 @@ class Command:
             self.cooldown_manager.add_cooldown(context)
         # Add the start slice on to the length to offset the section of arg_details being extracted
         arg_details = list(self.arg_details.args.values())[1 : len(args) + 1]
-        new_args = await self._convert_args(context, args[: len(arg_details)], arg_details)
-        new_args = [*new_args, *args[len(arg_details) :]]
+        new_args = await self._convert_args(
+            context, args if self.arg_details.has_var_positional else args[: len(arg_details)], arg_details
+        )
 
         if kwargs:
             new_kwarg = (

--- a/lightbulb/errors.py
+++ b/lightbulb/errors.py
@@ -179,6 +179,28 @@ class UnclosedQuotes(CommandSyntaxError):
         """The text that caused the error to be raised."""
 
 
+class UnexpectedQuotes(CommandSyntaxError):
+    """
+    Error raised when a quote mark is found in non-quoted string.
+    """
+
+    def __init__(self, quote: str) -> None:
+        super().__init__()
+        self.quote = quote
+        """The quote mark that caused the error to be raised."""
+
+
+class ExpectedSpaces(CommandSyntaxError):
+    """
+    Error raised when no spaces found in the end of a quoted string
+    """
+
+    def __init__(self, char: str) -> None:
+        super().__init__()
+        self.char = char
+        """The character that's expected to be a space character"""
+
+
 class CheckFailure(CommandError):
     """
     Base error that is raised when a check fails for a command. Anything raised by a check

--- a/tests/test_stringview.py
+++ b/tests/test_stringview.py
@@ -26,9 +26,10 @@ def test_stringview_splits_normal_args():
     assert sv.deconstruct_str() == (["I", "am", "thommo"], "")
 
 
-def test_stringview_splits_quoted_args():
-    sv = stringview.StringView('I "am thommo"')
-    assert sv.deconstruct_str() == (["I", "am thommo"], "")
+@pytest.mark.parametrize("text", ['I "am" thommo', "I 「am」 thommo"])
+def test_stringview_splits_quoted_args(text):
+    sv = stringview.StringView(text)
+    assert sv.deconstruct_str() == (["I", "am", "thommo"], "")
 
 
 def test_stringview_raises_UnclosedQuotes():
@@ -36,3 +37,17 @@ def test_stringview_raises_UnclosedQuotes():
     with pytest.raises(errors.UnclosedQuotes) as exc_info:
         sv.deconstruct_str()
     assert exc_info.type is errors.UnclosedQuotes
+
+
+def test_stringview_raises_UnexpectedQuotes():
+    sv = stringview.StringView('I"am" thommo')
+    with pytest.raises(errors.UnexpectedQuotes) as exc_info:
+        sv.deconstruct_str()
+    assert exc_info.type is errors.UnexpectedQuotes
+
+
+def test_stringview_raises_ExpectedSpaces():
+    sv = stringview.StringView('I "am"thommo')
+    with pytest.raises(errors.ExpectedSpaces) as exc_info:
+        sv.deconstruct_str()
+    assert exc_info.type is errors.ExpectedSpaces


### PR DESCRIPTION
### Summary
1. Fixed an issue where let's say, we have a command x:

    ```
    async def x(ctx: Context, *args: str) -> None:
        ...
    ```
    Doing `x a b c` will only pass `('a',)` on to the args parameter.

    Edit: Turned out this only happened with BoundCommand. This PR fixed another issue though. Let's say we have a command y:

    ```
    async def y(ctx: Context, *args: int) -> None:
        ...
    ```
    Doing `y 1 2 3` will only convert `1` to int and leave `2` and `3` as string;
2. Fixed StringView where it would return `(['a', '', 'b', 'c'], '')` when parsing `"a" b "c"`. Now it returns `(['a', 'b', 'c'], '')` instead;
3. Get `expect_quote` from the mapping instead;
4. Added more syntax errors.


### Checklist
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
