### PR TITLE
Fix typing.Optional behaviour and bring back var positional argument support

### DIFF
--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -806,7 +806,6 @@ class Bot(hikari.BotApp):
             except (ValueError, TypeError, errors.ConverterFailure):
                 raise errors.ConverterFailure(f"Converting failed for argument: {arg_name}")
 
-            print(conv_out)
             if isinstance(conv_out, dict):
                 kwargs.update(conv_out)
             elif isinstance(conv, _GreedyConverter) and conv.unpack:

--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -41,7 +41,6 @@ from lightbulb import help as help_
 from lightbulb import plugins
 from lightbulb.converters import _DefaultingConverter
 from lightbulb.converters import _GreedyConverter
-from lightbulb.converters import _UnionConverter
 from lightbulb.utils import maybe_await
 
 _LOGGER = logging.getLogger("lightbulb")
@@ -795,10 +794,7 @@ class Bot(hikari.BotApp):
             conv = converters.pop(0)
             arg_name = arg_names.pop(0)
 
-            if (
-                not isinstance(conv, (_DefaultingConverter, _UnionConverter))
-                or (isinstance(conv, _UnionConverter) and not conv.has_none_type)
-            ) and not arg_string:
+            if not isinstance(conv, _DefaultingConverter) and not arg_string:
                 raise errors.NotEnoughArguments(command, [arg_name, *arg_names])
 
             try:

--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -39,7 +39,7 @@ from lightbulb import errors
 from lightbulb import events
 from lightbulb import help as help_
 from lightbulb import plugins
-from lightbulb.converters import _DefaultingConverter
+from lightbulb.converters import _DefaultingConverter, _GreedyConverter
 from lightbulb.utils import maybe_await
 
 _LOGGER = logging.getLogger("lightbulb")
@@ -803,6 +803,8 @@ class Bot(hikari.BotApp):
 
             if isinstance(conv_out, dict):
                 kwargs.update(conv_out)
+            elif isinstance(conv, _GreedyConverter) and conv.unpack:
+                args.extend(conv_out)
             else:
                 args.append(conv_out)
 

--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -794,7 +794,7 @@ class Bot(hikari.BotApp):
             conv = converters.pop(0)
             arg_name = arg_names.pop(0)
 
-            if not isinstance(conv, (_DefaultingConverter, _GreedyConverter)) and not arg_string:
+            if not isinstance(conv, _DefaultingConverter) and not getattr(conv, "unpack", False) and not arg_string:
                 raise errors.NotEnoughArguments(command, [arg_name, *arg_names])
 
             try:

--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -794,7 +794,7 @@ class Bot(hikari.BotApp):
             conv = converters.pop(0)
             arg_name = arg_names.pop(0)
 
-            if not isinstance(conv, _DefaultingConverter) and not getattr(conv, "unpack", False) and not arg_string:
+            if not isinstance(conv, (_DefaultingConverter, _GreedyConverter)) and not arg_string:
                 raise errors.NotEnoughArguments(command, [arg_name, *arg_names])
 
             try:

--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -794,7 +794,7 @@ class Bot(hikari.BotApp):
             conv = converters.pop(0)
             arg_name = arg_names.pop(0)
 
-            if not isinstance(conv, _DefaultingConverter) and not arg_string:
+            if not isinstance(conv, (_DefaultingConverter, _GreedyConverter)) and not arg_string:
                 raise errors.NotEnoughArguments(command, [arg_name, *arg_names])
 
             try:

--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -39,7 +39,9 @@ from lightbulb import errors
 from lightbulb import events
 from lightbulb import help as help_
 from lightbulb import plugins
-from lightbulb.converters import _DefaultingConverter, _GreedyConverter, _UnionConverter
+from lightbulb.converters import _DefaultingConverter
+from lightbulb.converters import _GreedyConverter
+from lightbulb.converters import _UnionConverter
 from lightbulb.utils import maybe_await
 
 _LOGGER = logging.getLogger("lightbulb")

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -188,7 +188,7 @@ class SignatureInspector:
             if idx == 0 or (idx == 1 and self.has_self):
                 continue
 
-            converter = base_converter = self.get_converter(param.annotation)
+            converter: _BaseConverter = self.get_converter(param.annotation)
 
             if param.kind is inspect.Parameter.KEYWORD_ONLY:
                 converter = _ConsumeRestConverter(converter, param.name)
@@ -197,9 +197,7 @@ class SignatureInspector:
 
             if param.default is not inspect.Parameter.empty:
                 if not isinstance(converter, _DefaultingConverter):
-                    converter = _DefaultingConverter(
-                        converter, param.default, raise_on_fail=not isinstance(base_converter, _GreedyConverter)
-                    )
+                    converter = _DefaultingConverter(converter, param.default)
                 else:
                     converter.default = param.default
 

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -187,7 +187,7 @@ class SignatureInspector:
             if param.kind is inspect.Parameter.KEYWORD_ONLY:
                 converter = _ConsumeRestConverter(converter, param.name)
             elif param.kind is inspect.Parameter.VAR_POSITIONAL:
-                converter = _GreedyConverter(converter)
+                converter = _GreedyConverter(converter, unpack=True)
 
             if param.default is not inspect.Parameter.empty:
                 if not isinstance(converter, _DefaultingConverter):

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -157,7 +157,7 @@ class SignatureInspector:
 
         if origin is typing.Union:
             arguments: typing.List[_ConverterT] = [self.get_converter(conv) for conv in args]
-            return _UnionConverter(*arguments, has_none_type=type(None) in args)
+            return _UnionConverter(*arguments, has_none_type=None.__class__ in args)
 
         if origin is converters.Greedy:
             return _GreedyConverter(self.get_converter(args[0]))

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -52,6 +52,7 @@ _LOGGER = logging.getLogger("lightbulb")
 
 _CommandT = typing.TypeVar("_CommandT", bound="Command")
 T = typing.TypeVar("T")
+_ConverterT = typing.Union[_BaseConverter[T], _BaseConverter[typing.List[T]]]
 
 _CONVERTER_CLASS_MAPPING = {
     hikari.User: converters.user_converter,
@@ -139,7 +140,7 @@ class SignatureInspector:
         if self.has_self:
             self.arguments.pop(0)
 
-    def get_converter(self, annotation) -> _BaseConverter[T]:
+    def get_converter(self, annotation) -> _ConverterT:
         """
         Resolve the converter order for a given type annotation recursively.
 
@@ -155,7 +156,7 @@ class SignatureInspector:
         args = typing.get_args(annotation)
 
         if origin is typing.Union:
-            arguments = [self.get_converter(conv) for conv in args]
+            arguments: typing.List[_ConverterT] = [self.get_converter(conv) for conv in args]
             return _UnionConverter(*arguments, has_none_type=type(None) in args)
 
         if origin is converters.Greedy:

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -188,7 +188,7 @@ class SignatureInspector:
             if idx == 0 or (idx == 1 and self.has_self):
                 continue
 
-            converter: _BaseConverter = self.get_converter(param.annotation)
+            converter = base_converter = self.get_converter(param.annotation)
 
             if param.kind is inspect.Parameter.KEYWORD_ONLY:
                 converter = _ConsumeRestConverter(converter, param.name)
@@ -197,7 +197,9 @@ class SignatureInspector:
 
             if param.default is not inspect.Parameter.empty:
                 if not isinstance(converter, _DefaultingConverter):
-                    converter = _DefaultingConverter(converter, param.default)
+                    converter = _DefaultingConverter(
+                        converter, param.default, raise_on_fail=not isinstance(base_converter, _GreedyConverter)
+                    )
                 else:
                     converter.default = param.default
 

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -178,20 +178,22 @@ class SignatureInspector:
         """
         arg_converters = []
 
-        params = list(signature.parameters.values())
-        for arg_i in range(len(signature.parameters)):
-            if arg_i == 0 or (arg_i == 1 and self.has_self):
+        for idx, param in enumerate(signature.parameters.values()):
+            if idx == 0 or (idx == 1 and self.has_self):
                 continue
 
-            converter = self.get_converter(params[arg_i].annotation)
+            converter = self.get_converter(param.annotation)
 
-            if params[arg_i].kind is inspect.Parameter.KEYWORD_ONLY:
-                converter = _ConsumeRestConverter(converter, params[arg_i].name)
-            elif params[arg_i].kind is inspect.Parameter.VAR_POSITIONAL:
+            if param.kind is inspect.Parameter.KEYWORD_ONLY:
+                converter = _ConsumeRestConverter(converter, param.name)
+            elif param.kind is inspect.Parameter.VAR_POSITIONAL:
                 converter = _GreedyConverter(converter)
 
-            if params[arg_i].default is not inspect.Parameter.empty and not isinstance(converter, _DefaultingConverter):
-                converter = _DefaultingConverter(converter, params[arg_i].default)
+            if param.default is not inspect.Parameter.empty:
+                if not isinstance(converter, _DefaultingConverter):
+                    converter = _DefaultingConverter(converter, param.default)
+                else:
+                    converter.default = param.default
 
             arg_converters.append(converter)
         return arg_converters

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -156,7 +156,7 @@ class SignatureInspector:
 
         if origin is typing.Union:
             if args[1] is type(None):
-                return _DefaultingConverter(self.get_converter(args[0]), None)
+                return _DefaultingConverter(self.get_converter(args[0]), None, raise_on_fail=False)
             args = [self.get_converter(conv) for conv in args]
             return _UnionConverter(*args)
 

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -514,6 +514,10 @@ class _UnionConverter:
             try:
                 converted_arg = await converter.convert(context, " ".join(args), parse=False)
                 converted = True
+
+                if getattr(converter, "conversion_func", None) is type(None):
+                    remainder = converted_arg[1]
+
                 break
             except (ValueError, TypeError, errors.ConverterFailure):
                 continue

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -540,9 +540,6 @@ class _GreedyConverter:
             except Exception:
                 break
 
-        if not converted and not self.unpack:
-            raise errors.ConverterFailure
-
         return converted, prev
 
 

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -519,7 +519,7 @@ class _UnionConverter:
                     remainder = converted_arg[1]
 
                 break
-            except (ValueError, TypeError, errors.ConverterFailure):
+            except Exception:
                 continue
 
         if not converted:
@@ -551,7 +551,7 @@ class _GreedyConverter:
                 converted_arg = await self.converter.convert(context, " ".join(args), parse=False)
                 converted.append(converted_arg[0])
                 prev = remainder
-            except (ValueError, TypeError, errors.ConverterFailure):
+            except Exception:
                 break
 
         return converted, prev

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -540,6 +540,9 @@ class _GreedyConverter:
             except Exception:
                 break
 
+        if not converted and not self.unpack:
+            raise errors.ConverterFailure
+
         return converted, prev
 
 

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -514,10 +514,11 @@ class _UnionConverter:
 
 
 class _GreedyConverter:
-    __slots__ = ("converter",)
+    __slots__ = ("converter", "unpack")
 
-    def __init__(self, converter: _Converter) -> None:
+    def __init__(self, converter: _Converter, unpack: bool = False) -> None:
         self.converter = converter
+        self.unpack = unpack
 
     async def convert(self, context: context_.Context, arg_string: str) -> typing.Tuple[typing.List[T], str]:
         prev = arg_string

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -580,21 +580,18 @@ class _DefaultingConverter:
     async def convert(
         self, context: context_.Context, arg_string: str, *, parse: bool = False
     ) -> typing.Tuple[typing.Union[dict, T], str]:
-        sv = stringview.StringView(arg_string)
-        args, remainder = sv.deconstruct_str(max_parse=1)
-
-        if not args:
+        if not arg_string:
             return self.default, ""
 
         try:
-            converted_arg = await self.converter.convert(context, " ".join(args), parse=False)
+            converted_arg = await self.converter.convert(context, arg_string, parse=True)
         except Exception:
             if self.raise_on_fail:
                 raise
 
             return self.default, arg_string
 
-        return converted_arg[0], remainder
+        return converted_arg
 
 
 class _ConsumeRestConverter:

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -541,11 +541,12 @@ class _GreedyConverter:
 
 
 class _DefaultingConverter:
-    __slots__ = ("converter", "default")
+    __slots__ = ("converter", "default", "raise_on_fail")
 
-    def __init__(self, converter: _Converter, default: typing.Any):
+    def __init__(self, converter: _Converter, default: typing.Any, raise_on_fail: bool = True):
         self.converter = converter
         self.default = default
+        self.raise_on_fail = raise_on_fail
 
     async def convert(self, context: context_.Context, arg_string: str) -> typing.Tuple[T, str]:
         sv = stringview.StringView(arg_string)
@@ -557,6 +558,9 @@ class _DefaultingConverter:
         try:
             converted_arg, _ = await self.converter.convert(context, " ".join(args), parse=False)
         except (ValueError, TypeError, errors.ConverterFailure):
+            if self.raise_on_fail:
+                raise
+
             return self.default, arg_string
 
         return converted_arg, remainder

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -492,7 +492,7 @@ class _Converter:
         if self.conversion_func is not type(None):
             arguments.append(WrappedArg(args, context))
         else:
-            remainder = arg_string
+            remainder = args
 
         converted_arg = await utils.maybe_await(self.conversion_func, *arguments)
         return converted_arg, remainder

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -553,7 +553,11 @@ class _DefaultingConverter:
         if not args:
             return self.default, ""
 
-        converted_arg, _ = await self.converter.convert(context, " ".join(args), parse=False)
+        try:
+            converted_arg, _ = await self.converter.convert(context, " ".join(args), parse=False)
+        except (ValueError, TypeError, errors.ConverterFailure):
+            return self.default, arg_string
+
         return converted_arg, remainder
 
 

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -489,7 +489,7 @@ class _Converter:
             args = " ".join(parsed)
 
         arguments = []
-        if self.conversion_func is not type(None):
+        if self.conversion_func is not None.__class__:
             arguments.append(WrappedArg(args, context))
         else:
             remainder = args
@@ -515,7 +515,7 @@ class _UnionConverter:
                 converted_arg = await converter.convert(context, " ".join(args), parse=False)
                 converted = True
 
-                if getattr(converter, "conversion_func", None) is type(None):
+                if getattr(converter, "conversion_func", None) is None.__class__:
                     remainder = converted_arg[1]
 
                 break

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -471,9 +471,7 @@ class _ConverterT(typing.Protocol[T_co]):
 
 
 class _BaseConverter(typing.Protocol[T_co]):
-    async def convert(
-        self, context: context_.Context, arg_string: str, *, parse: bool
-    ) -> typing.Tuple[typing.Union[T_co, typing.List[T_co]], str]:
+    async def convert(self, context: context_.Context, arg_string: str, *, parse: bool) -> typing.Tuple[T_co, str]:
         ...
 
 
@@ -574,8 +572,8 @@ class _DefaultingConverter:
 
             return self.default, ""
 
-        converted_arg, _ = await self.converter.convert(context, " ".join(args), parse=False)
-        return converted_arg, remainder
+        converted_arg = await self.converter.convert(context, " ".join(args), parse=False)
+        return converted_arg[0], remainder
 
 
 class _ConsumeRestConverter:

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -8,11 +8,14 @@ def assert_converters_recursively(
     converter: typing.Optional[converters._BaseConverter],
     types: typing.Sequence[typing.Type[converters._BaseConverter]],
     idx: int = 0,
+    *,
+    default: typing.Any,
 ) -> None:
     if converter is None:
         return
 
     assert isinstance(converter, types[idx])
+    assert getattr(converter, "_default", default) is default
 
     try:
         return getattr(converter, "converter", None)
@@ -30,10 +33,10 @@ async def union_test2(ctx, test_arg: typing.Optional[int] = 1):
     ...
 
 
-@pytest.mark.parametrize("command", [union_test1, union_test2])
-def test_has_union_converter_wrapped_in_defaulting_converter(command):
+@pytest.mark.parametrize("command, default", [(union_test1, None), (union_test2, 1)])
+def test_has_union_converter_wrapped_in_defaulting_converter(command, default):
     converter_types = [converters._DefaultingConverter, converters._UnionConverter]
-    assert_converters_recursively(command.arg_details.converters[0], converter_types)
+    assert_converters_recursively(command.arg_details.converters[0], converter_types, default=default)
 
 
 def test_has_union_converter_wrapped_in_consume_rest_converter_in_defaulting_converter():
@@ -47,7 +50,7 @@ def test_has_union_converter_wrapped_in_consume_rest_converter_in_defaulting_con
         converters._DefaultingConverter,
         converters._UnionConverter,
     ]
-    assert_converters_recursively(test.arg_details.converters[0], converter_types)
+    assert_converters_recursively(test.arg_details.converters[0], converter_types, default=1)
 
 
 def test_has_consume_rest_converter():
@@ -64,7 +67,7 @@ def test_has_defaulting_converter():
         ...
 
     converter_types = [converters._DefaultingConverter, converters._ConsumeRestConverter]
-    assert_converters_recursively(test.arg_details.converters[0], converter_types)
+    assert_converters_recursively(test.arg_details.converters[0], converter_types, default="test")
 
 
 @commands.command()

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1,0 +1,66 @@
+import typing
+
+import pytest
+from lightbulb import commands, converters
+
+
+def test_has_union_converter():
+    @commands.command()
+    async def test(ctx, test_arg: typing.Optional[int]):
+        ...
+
+    assert isinstance(test.arg_details.converters[0], converters._UnionConverter)
+
+
+def test_has_union_converter_wrapped_in_defaulting_converter():
+    @commands.command()
+    async def test(ctx, test_arg: typing.Optional[int] = 1):
+        ...
+
+    converter = test.arg_details.converters[0]
+    assert isinstance(converter, converters._DefaultingConverter)
+    assert isinstance(converter.converter, converters._UnionConverter)
+
+
+def test_has_union_converter_wrapped_in_consume_rest_converter_in_defaulting_converter():
+    @commands.command()
+    async def test(ctx, *, test_arg: typing.Optional[int] = 1):
+        ...
+
+    converter = test.arg_details.converters[0]
+    assert isinstance(converter, converters._DefaultingConverter)
+    assert isinstance(converter.converter, converters._ConsumeRestConverter)
+    assert isinstance(converter.converter.converter, converters._UnionConverter)
+
+
+def test_has_consume_rest_converter():
+    @commands.command()
+    async def test(ctx, *, test_arg: str):
+        ...
+
+    assert isinstance(test.arg_details.converters[0], converters._ConsumeRestConverter)
+
+
+def test_has_defaulting_converter():
+    @commands.command()
+    async def test(ctx, *, test_arg: str = "test"):
+        ...
+
+    converter = test.arg_details.converters[0]
+    assert isinstance(converter, converters._DefaultingConverter)
+    assert isinstance(converter.converter, converters._ConsumeRestConverter)
+
+
+@commands.command()
+async def greedy_test1(ctx, *test_arg: int):
+    ...
+
+
+@commands.command()
+async def greedy_test2(ctx, test_arg: converters.Greedy[int]):
+    ...
+
+
+@pytest.mark.parametrize("command", [greedy_test1, greedy_test2])
+def test_has_greedy_converter(command):
+    assert isinstance(command.arg_details.converters[0], converters._GreedyConverter)


### PR DESCRIPTION
### Summary
Parameters typed with typing.Optional should have `None` argument if no argument was passed and/or **the converter failed**.

Suppose we have a command x: ```
async def x(ctx: Context, amount: Optional[int], *, stuff: str):
    ...```

Doing:
1. `x 1 bag` should pass `1` onto amount and `"bag"` onto stuff
2. `x bag` should pass `None` onto amount and `"bag"` onto stuff

### Checklist
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.
