### PR TITLE
Draft: Add option to return no bucket on dynamic cooldown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![PyPI](https://img.shields.io/pypi/v/hikari-lightbulb)
+
 # Lightbulb
 Lightbulb is designed to be an easy to use command handler library that integrates with the 
 Discord API wrapper library for Python, Hikari.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,12 +8,41 @@ If you think anything is missing, make a merge request to add it, or contact tho
 
 ----
 
+Version 0.0.61
+==============
+
+**Breaking Changes**
+
+- Removed ``ArgInfo`` dataclass.
+
+- Rewritten :obj:`~lightbulb.commands.SignatureInspector` class.
+
+- :obj:`~lightbulb.command_handler.Bot.resolve_args_for_command` now takes an additional argument ``context``.
+
+- Calling :obj:`~lightbulb.commands.Command.invoke` will no longer process converters.
+
+- Changed :obj:`~lightbulb.cooldowns.CooldownManager.add_cooldown` into a coroutine.
+
+**Other Changes**
+
+- Added :obj:`~lightbulb.checks.has_attachment`.
+
+- Added :obj:`~lightbulb.checks.check_exempt`.
+
+- Fixed :obj:`KeyError` being raised when attempting to remove a command/plugin that doesn't exist
+
+- Created class mapping for converters. See :ref:`converters` for details.
+
+- Added support for custom cooldowns through the :obj:`~lightbulb.cooldowns.dynamic_cooldown` decorator.
+
+- Added :obj:`lightbulb.converters.Greedy` converter.
+
 Version 0.0.60
 ==============
 
-- Added :obj:`~lightbulb.events.LightbulbEvent.bot` property
+- Added :obj:`~lightbulb.events.LightbulbEvent.bot` property.
 
-- Fixed admin permission checks not working as expected
+- Fixed admin permission checks not working as expected.
 
 Version 0.0.59
 ==============

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -48,6 +48,8 @@ already exists for your bug or feature.
 
 - `norizon#2612 <https://github.com/norinorin>`_
 
+- `Tmpod#2525 <https://tmpod.dev>`_
+
 **Index:**
 
 .. toctree::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -46,6 +46,8 @@ already exists for your bug or feature.
 
 - `M.A#4999 <https://gitlab.com/MonAaraj>`_
 
+- `norizon#2612 <https://github.com/norinorin>`_
+
 **Index:**
 
 .. toctree::

--- a/lightbulb/__init__.py
+++ b/lightbulb/__init__.py
@@ -53,4 +53,4 @@ __all__: typing.Final[typing.List[str]] = [
     *events.__all__,
 ]
 
-__version__ = "0.0.60"
+__version__ = "0.0.61"

--- a/lightbulb/checks.py
+++ b/lightbulb/checks.py
@@ -35,6 +35,7 @@ __all__: typing.Final[typing.List[str]] = [
     "bot_has_permissions",
     "has_attachment",
     "check",
+    "check_exempt",
 ]
 
 import functools
@@ -561,6 +562,34 @@ def check(check_func: typing.Callable[[context.Context], typing.Coroutine[typing
     def decorate(command: T_inv) -> T_inv:
         _check_check_decorator_above_commands_decorator(command)
         command.add_check(check_func)
+        return command
+
+    return decorate
+
+
+def check_exempt(predicate):
+    """
+    A decorator which allows checks to be bypassed if the ``predicate`` conditions are met. Predicate can
+    be a coroutine or a normal function but must take a single argument - ``context`` - and must return a
+    boolean - ``True`` if checks should be bypassed or ``False`` if not.
+
+    Args:
+        predicate: The callable which determines if command checks should be bypassed or not.
+
+    Example:
+
+        .. code-block:: python
+
+            @checks.check_exempt(lambda ctx: ctx.author.id == 1234)
+            @checks.guild_only()
+            @bot.command()
+            async def foo(ctx):
+                await ctx.respond("foo")
+    """
+
+    def decorate(command: T_inv) -> T_inv:
+        _check_check_decorator_above_commands_decorator(command)
+        command._check_exempt_predicate = predicate
         return command
 
     return decorate

--- a/lightbulb/checks.py
+++ b/lightbulb/checks.py
@@ -237,9 +237,7 @@ async def _bot_has_permissions(ctx: context.Context, *, permissions: hikari.Perm
 
 
 async def _has_attachment(
-        ctx: context.Context,
-        *,
-        allowed_extensions: typing.Optional[typing.Sequence[str]] = None
+    ctx: context.Context, *, allowed_extensions: typing.Optional[typing.Sequence[str]] = None
 ) -> bool:
     if not ctx.attachments:
         raise errors.MissingRequiredAttachment("Missing attachment(s) required to run the command")

--- a/lightbulb/checks.py
+++ b/lightbulb/checks.py
@@ -569,9 +569,9 @@ def check(check_func: typing.Callable[[context.Context], typing.Coroutine[typing
 
 def check_exempt(predicate):
     """
-    A decorator which allows checks to be bypassed if the ``predicate`` conditions are met. Predicate can
-    be a coroutine or a normal function but must take a single argument - ``context`` - and must return a
-    boolean - ``True`` if checks should be bypassed or ``False`` if not.
+    A decorator which allows **all** checks to be bypassed if the ``predicate`` conditions are met.
+    Predicate can be a coroutine or a normal function but must take a single
+    argument - ``context`` - and must return a boolean - ``True`` if checks should be bypassed or ``False`` if not.
 
     Args:
         predicate: The callable which determines if command checks should be bypassed or not.

--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -806,7 +806,6 @@ class Bot(hikari.BotApp):
             except (ValueError, TypeError, errors.ConverterFailure):
                 raise errors.ConverterFailure(f"Converting failed for argument: {arg_name}")
 
-            print(conv_out)
             if isinstance(conv_out, dict):
                 kwargs.update(conv_out)
             elif isinstance(conv, _GreedyConverter) and conv.unpack:

--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -41,7 +41,6 @@ from lightbulb import help as help_
 from lightbulb import plugins
 from lightbulb.converters import _DefaultingConverter
 from lightbulb.converters import _GreedyConverter
-from lightbulb.converters import _UnionConverter
 from lightbulb.utils import maybe_await
 
 _LOGGER = logging.getLogger("lightbulb")
@@ -795,10 +794,7 @@ class Bot(hikari.BotApp):
             conv = converters.pop(0)
             arg_name = arg_names.pop(0)
 
-            if (
-                not isinstance(conv, (_DefaultingConverter, _UnionConverter))
-                or (isinstance(conv, _UnionConverter) and not conv.has_none_type)
-            ) and not arg_string:
+            if not isinstance(conv, _DefaultingConverter) and not arg_string:
                 raise errors.NotEnoughArguments(command, [arg_name, *arg_names])
 
             try:

--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -39,7 +39,7 @@ from lightbulb import errors
 from lightbulb import events
 from lightbulb import help as help_
 from lightbulb import plugins
-from lightbulb.converters import _DefaultingConverter
+from lightbulb.converters import _DefaultingConverter, _GreedyConverter
 from lightbulb.utils import maybe_await
 
 _LOGGER = logging.getLogger("lightbulb")
@@ -803,6 +803,8 @@ class Bot(hikari.BotApp):
 
             if isinstance(conv_out, dict):
                 kwargs.update(conv_out)
+            elif isinstance(conv, _GreedyConverter) and conv.unpack:
+                args.extend(conv_out)
             else:
                 args.append(conv_out)
 

--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -480,12 +480,11 @@ class Bot(hikari.BotApp):
 
         self.commands.remove(command)
 
-        if command is not None:
-            keys_to_remove = [command.name, *command._aliases]
-            keys_to_remove.remove(name)
-            for key in keys_to_remove:
-                self._commands.pop(key)
-            _LOGGER.debug("command removed: %s", command.name)
+        keys_to_remove = [command.name, *command._aliases]
+        keys_to_remove.remove(name)
+        for key in keys_to_remove:
+            self._commands.pop(key)
+        _LOGGER.debug("command removed: %s", command.name)
 
         return command.name
 
@@ -506,17 +505,16 @@ class Bot(hikari.BotApp):
 
         plugin.plugin_remove()
 
-        if plugin is not None:
-            for k in plugin._commands.keys():
-                self.remove_command(k)
+        for k in plugin._commands.keys():
+            self.remove_command(k)
 
-            for event_type, listeners in plugin.listeners.items():
-                for listener in listeners:
-                    callback = listener.__get__(plugin, type(plugin))
-                    self.unsubscribe(listener.event_type, callback)
-                    _LOGGER.debug("listener removed: %s (%s)", callback.__name__, listener.event_type.__name__)
+        for event_type, listeners in plugin.listeners.items():
+            for listener in listeners:
+                callback = listener.__get__(plugin, type(plugin))
+                self.unsubscribe(listener.event_type, callback)
+                _LOGGER.debug("listener removed: %s (%s)", callback.__name__, listener.event_type.__name__)
 
-            _LOGGER.debug("plugin removed: %s", plugin.name)
+        _LOGGER.debug("plugin removed: %s", plugin.name)
 
         return plugin.name
 

--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -794,7 +794,7 @@ class Bot(hikari.BotApp):
             conv = converters.pop(0)
             arg_name = arg_names.pop(0)
 
-            if not isinstance(conv, (_DefaultingConverter, _GreedyConverter)) and not arg_string:
+            if not isinstance(conv, _DefaultingConverter) and not getattr(conv, "unpack", False) and not arg_string:
                 raise errors.NotEnoughArguments(command, [arg_name, *arg_names])
 
             try:

--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -794,7 +794,7 @@ class Bot(hikari.BotApp):
             conv = converters.pop(0)
             arg_name = arg_names.pop(0)
 
-            if not isinstance(conv, _DefaultingConverter) and not getattr(conv, "unpack", False) and not arg_string:
+            if not isinstance(conv, (_DefaultingConverter, _GreedyConverter)) and not arg_string:
                 raise errors.NotEnoughArguments(command, [arg_name, *arg_names])
 
             try:

--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -864,7 +864,10 @@ class Bot(hikari.BotApp):
 
         try:
             positional_args, keyword_arg = self.resolve_args_for_command(command, final_args)
-            await self._evaluate_checks(command, context)
+            if not await maybe_await(command._check_exempt_predicate, context):
+                await self._evaluate_checks(command, context)
+            else:
+                _LOGGER.debug("Checks bypassed for command: %s", context.message.content)
         except (
             errors.NotEnoughArguments,
             errors.TooManyArguments,

--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -794,7 +794,7 @@ class Bot(hikari.BotApp):
             conv = converters.pop(0)
             arg_name = arg_names.pop(0)
 
-            if not isinstance(conv, _DefaultingConverter) and not arg_string:
+            if not isinstance(conv, (_DefaultingConverter, _GreedyConverter)) and not arg_string:
                 raise errors.NotEnoughArguments(command, [arg_name, *arg_names])
 
             try:

--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -39,7 +39,9 @@ from lightbulb import errors
 from lightbulb import events
 from lightbulb import help as help_
 from lightbulb import plugins
-from lightbulb.converters import _DefaultingConverter, _GreedyConverter, _UnionConverter
+from lightbulb.converters import _DefaultingConverter
+from lightbulb.converters import _GreedyConverter
+from lightbulb.converters import _UnionConverter
 from lightbulb.utils import maybe_await
 
 _LOGGER = logging.getLogger("lightbulb")

--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -473,15 +473,21 @@ class Bot(hikari.BotApp):
         Returns:
             Optional[ :obj:`str` ]: Name of the command that was removed.
         """
-        command = self._commands.pop(name)
+        command = self._commands.pop(name, None)
+
+        if command is None:
+            return None
+
         self.commands.remove(command)
+
         if command is not None:
             keys_to_remove = [command.name, *command._aliases]
             keys_to_remove.remove(name)
             for key in keys_to_remove:
                 self._commands.pop(key)
             _LOGGER.debug("command removed: %s", command.name)
-        return command.name if command is not None else None
+
+        return command.name
 
     def remove_plugin(self, name: str) -> typing.Optional[str]:
         """
@@ -493,7 +499,11 @@ class Bot(hikari.BotApp):
         Returns:
             Optional[ :obj:`str` ]: Name of the plugin that was removed.
         """
-        plugin = self.plugins.pop(name)
+        plugin = self.plugins.pop(name, None)
+
+        if plugin is None:
+            return None
+
         plugin.plugin_remove()
 
         if plugin is not None:
@@ -507,7 +517,8 @@ class Bot(hikari.BotApp):
                     _LOGGER.debug("listener removed: %s (%s)", callback.__name__, listener.event_type.__name__)
 
             _LOGGER.debug("plugin removed: %s", plugin.name)
-        return plugin.name if plugin is not None else None
+
+        return plugin.name
 
     def load_extension(self, extension: str) -> None:
         """

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -188,7 +188,7 @@ class SignatureInspector:
             if idx == 0 or (idx == 1 and self.has_self):
                 continue
 
-            converter = base_converter = self.get_converter(param.annotation)
+            converter: _BaseConverter = self.get_converter(param.annotation)
 
             if param.kind is inspect.Parameter.KEYWORD_ONLY:
                 converter = _ConsumeRestConverter(converter, param.name)
@@ -197,9 +197,7 @@ class SignatureInspector:
 
             if param.default is not inspect.Parameter.empty:
                 if not isinstance(converter, _DefaultingConverter):
-                    converter = _DefaultingConverter(
-                        converter, param.default, raise_on_fail=not isinstance(base_converter, _GreedyConverter)
-                    )
+                    converter = _DefaultingConverter(converter, param.default)
                 else:
                     converter.default = param.default
 

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -187,7 +187,7 @@ class SignatureInspector:
             if param.kind is inspect.Parameter.KEYWORD_ONLY:
                 converter = _ConsumeRestConverter(converter, param.name)
             elif param.kind is inspect.Parameter.VAR_POSITIONAL:
-                converter = _GreedyConverter(converter)
+                converter = _GreedyConverter(converter, unpack=True)
 
             if param.default is not inspect.Parameter.empty:
                 if not isinstance(converter, _DefaultingConverter):

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -41,7 +41,8 @@ from lightbulb import converters
 from lightbulb import cooldowns
 from lightbulb import errors
 from lightbulb import events
-from lightbulb.utils import maybe_await, get
+from lightbulb.utils import get
+from lightbulb.utils import maybe_await
 
 if typing.TYPE_CHECKING:
     from lightbulb import plugins

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -157,7 +157,7 @@ class SignatureInspector:
 
         if origin is typing.Union:
             arguments: typing.List[_ConverterT] = [self.get_converter(conv) for conv in args]
-            return _UnionConverter(*arguments, has_none_type=type(None) in args)
+            return _UnionConverter(*arguments, has_none_type=None.__class__ in args)
 
         if origin is converters.Greedy:
             return _GreedyConverter(self.get_converter(args[0]))

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -221,6 +221,7 @@ class Command:
         self._aliases = aliases
         self.hidden = hidden
         self._checks = []
+        self._check_exempt_predicate = lambda ctx: False
         self._raw_error_listener = None
         self._raw_before_invoke = None
         self._raw_after_invoke = None
@@ -351,7 +352,7 @@ class Command:
         return self._callback
 
     @property
-    def checks(self) -> typing.Iterable[typing.Callable[[context.Context], bool]]:
+    def checks(self) -> typing.Iterable[typing.Callable[[context_.Context], bool]]:
         """
         The command's checks.
 
@@ -403,8 +404,8 @@ class Command:
         """
 
         def decorate(
-            func: typing.Callable[[context.Context], typing.Coroutine[None, None, typing.Any]]
-        ) -> typing.Callable[[context.Context], typing.Coroutine[None, None, typing.Any]]:
+            func: typing.Callable[[context_.Context], typing.Coroutine[None, None, typing.Any]]
+        ) -> typing.Callable[[context_.Context], typing.Coroutine[None, None, typing.Any]]:
             self._raw_before_invoke = func
             return func
 
@@ -419,8 +420,8 @@ class Command:
         """
 
         def decorate(
-            func: typing.Callable[[context.Context], typing.Coroutine[None, None, typing.Any]]
-        ) -> typing.Callable[[context.Context], typing.Coroutine[None, None, typing.Any]]:
+            func: typing.Callable[[context_.Context], typing.Coroutine[None, None, typing.Any]]
+        ) -> typing.Callable[[context_.Context], typing.Coroutine[None, None, typing.Any]]:
             self._raw_after_invoke = func
             return func
 
@@ -514,7 +515,7 @@ class Command:
 
         return await self._callback(context, *new_args, **kwargs)
 
-    def add_check(self, check_func: typing.Callable[[context.Context], typing.Coroutine[None, None, bool]]) -> None:
+    def add_check(self, check_func: typing.Callable[[context_.Context], typing.Coroutine[None, None, bool]]) -> None:
         """
         Add a check to an instance of :obj:`~.commands.Command` or a subclass. The check passed must
         be an awaitable function taking a single argument which will be an instance of :obj:`~.context.Context`.

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -74,7 +74,7 @@ def _bind_prototype(instance: typing.Any, command_template: _CommandT):
 
         async def invoke(self, context: context_.Context, *args: str, **kwargs: str) -> typing.Any:
             if self.cooldown_manager is not None:
-                self.cooldown_manager.add_cooldown(context)
+                await self.cooldown_manager.add_cooldown(context)
             # Add the start slice on to the length to offset the section of arg_details being extracted
             arg_details = list(self.arg_details.args.values())[2 : len(args) + 2]
             new_args = await self._convert_args(
@@ -500,7 +500,7 @@ class Command:
 
         """
         if self.cooldown_manager is not None:
-            self.cooldown_manager.add_cooldown(context)
+            await self.cooldown_manager.add_cooldown(context)
         # Add the start slice on to the length to offset the section of arg_details being extracted
         arg_details = list(self.arg_details.args.values())[1 : len(args) + 1]
         new_args = await self._convert_args(

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -558,7 +558,13 @@ class Command:
             :obj:`~.errors.CheckFailure`: If the command is not runnable in the context given.
         """
         for check in self._checks:
-            result = await check(context)
+            try:
+                result = await check(context)
+            except errors.MissingRequiredAttachment:
+                # Bypass attachment check because we still want the command to show for the help
+                # overview and it is unlikely that someone will call the help command with an attachment
+                # to the message.
+                result = True
             if result is False:
                 raise errors.CheckFailure(f"Check {check.__name__} failed for command {self.name}")
         return True

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -151,6 +151,8 @@ class SignatureInspector:
             The top level converter for the parameter
         """
         annotation = _CONVERTER_CLASS_MAPPING.get(annotation, annotation)
+        if isinstance(annotation, str):
+            annotation = str
 
         origin = typing.get_origin(annotation)
         args = typing.get_args(annotation)

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -52,6 +52,7 @@ _LOGGER = logging.getLogger("lightbulb")
 
 _CommandT = typing.TypeVar("_CommandT", bound="Command")
 T = typing.TypeVar("T")
+_ConverterT = typing.Union[_BaseConverter[T], _BaseConverter[typing.List[T]]]
 
 _CONVERTER_CLASS_MAPPING = {
     hikari.User: converters.user_converter,
@@ -139,7 +140,7 @@ class SignatureInspector:
         if self.has_self:
             self.arguments.pop(0)
 
-    def get_converter(self, annotation) -> _BaseConverter[T]:
+    def get_converter(self, annotation) -> _ConverterT:
         """
         Resolve the converter order for a given type annotation recursively.
 
@@ -155,7 +156,7 @@ class SignatureInspector:
         args = typing.get_args(annotation)
 
         if origin is typing.Union:
-            arguments = [self.get_converter(conv) for conv in args]
+            arguments: typing.List[_ConverterT] = [self.get_converter(conv) for conv in args]
             return _UnionConverter(*arguments, has_none_type=type(None) in args)
 
         if origin is converters.Greedy:

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -471,12 +471,15 @@ class Command:
             try:
                 new_arg = await self.handle_types(arg, details.annotation)
                 new_args.append(new_arg)
-            except (errors.ConverterFailure, ValueError):
+            except (errors.ConverterFailure, ValueError) as exc:
                 _LOGGER.error(
                     "Failed converting %s with converter: %s",
                     arg,
                     getattr(details.annotation, "__name__", repr(details.annotation)),
                 )
+                if isinstance(exc, errors.ConverterFailure) and exc.text:
+                    raise  # don't override the preset text
+
                 raise errors.ConverterFailure(
                     text=f"Failed converting {arg} with converter: {getattr(details.annotation, '__name__', repr(details.annotation))}"
                 )

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -474,6 +474,10 @@ class Command:
                 raise errors.ConverterFailure(
                     text=f"Failed converting {arg} with converter: {getattr(details.annotation, '__name__', repr(details.annotation))}"
                 )
+
+        if self.arg_details.has_var_positional:
+            new_args.extend(args[len(new_args) :])
+
         return new_args
 
     async def invoke(self, context: context_.Context, *args: str, **kwargs: str) -> typing.Any:

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -31,6 +31,7 @@ import functools
 import inspect
 import logging
 import typing
+from itertools import zip_longest
 
 import hikari
 from multidict import CIMultiDict
@@ -40,7 +41,7 @@ from lightbulb import converters
 from lightbulb import cooldowns
 from lightbulb import errors
 from lightbulb import events
-from lightbulb.utils import maybe_await
+from lightbulb.utils import maybe_await, get
 
 if typing.TYPE_CHECKING:
     from lightbulb import plugins
@@ -75,7 +76,10 @@ def _bind_prototype(instance: typing.Any, command_template: _CommandT):
             if self.cooldown_manager is not None:
                 self.cooldown_manager.add_cooldown(context)
             # Add the start slice on to the length to offset the section of arg_details being extracted
-            new_args = await self._convert_args(context, args, list(self.arg_details.args.values())[2 : len(args) + 2])
+            arg_details = list(self.arg_details.args.values())[2 : len(args) + 2]
+            new_args = await self._convert_args(
+                context, args if self.arg_details.has_var_positional else args[: len(arg_details)], arg_details
+            )
 
             if kwargs:
                 new_kwarg = (
@@ -457,7 +461,9 @@ class Command:
     ) -> typing.Sequence[typing.Any]:
         new_args = []
 
-        for arg, details in zip(args, arg_details):
+        for arg, details in zip_longest(
+            args, arg_details, fillvalue=get(arg_details, argtype=inspect.Parameter.VAR_POSITIONAL)
+        ):
             arg = converters.WrappedArg(arg, context)
             if details.annotation is inspect.Parameter.empty or isinstance(details.annotation, str):
                 new_args.append(str(arg))
@@ -474,10 +480,6 @@ class Command:
                 raise errors.ConverterFailure(
                     text=f"Failed converting {arg} with converter: {getattr(details.annotation, '__name__', repr(details.annotation))}"
                 )
-
-        if self.arg_details.has_var_positional:
-            new_args.extend(args[len(new_args) :])
-
         return new_args
 
     async def invoke(self, context: context_.Context, *args: str, **kwargs: str) -> typing.Any:
@@ -497,8 +499,9 @@ class Command:
             self.cooldown_manager.add_cooldown(context)
         # Add the start slice on to the length to offset the section of arg_details being extracted
         arg_details = list(self.arg_details.args.values())[1 : len(args) + 1]
-        new_args = await self._convert_args(context, args[: len(arg_details)], arg_details)
-        new_args = [*new_args, *args[len(arg_details) :]]
+        new_args = await self._convert_args(
+            context, args if self.arg_details.has_var_positional else args[: len(arg_details)], arg_details
+        )
 
         if kwargs:
             new_kwarg = (

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -188,7 +188,7 @@ class SignatureInspector:
             if idx == 0 or (idx == 1 and self.has_self):
                 continue
 
-            converter: _BaseConverter = self.get_converter(param.annotation)
+            converter = base_converter = self.get_converter(param.annotation)
 
             if param.kind is inspect.Parameter.KEYWORD_ONLY:
                 converter = _ConsumeRestConverter(converter, param.name)
@@ -197,7 +197,9 @@ class SignatureInspector:
 
             if param.default is not inspect.Parameter.empty:
                 if not isinstance(converter, _DefaultingConverter):
-                    converter = _DefaultingConverter(converter, param.default)
+                    converter = _DefaultingConverter(
+                        converter, param.default, raise_on_fail=not isinstance(base_converter, _GreedyConverter)
+                    )
                 else:
                     converter.default = param.default
 

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -178,20 +178,22 @@ class SignatureInspector:
         """
         arg_converters = []
 
-        params = list(signature.parameters.values())
-        for arg_i in range(len(signature.parameters)):
-            if arg_i == 0 or (arg_i == 1 and self.has_self):
+        for idx, param in enumerate(signature.parameters.values()):
+            if idx == 0 or (idx == 1 and self.has_self):
                 continue
 
-            converter = self.get_converter(params[arg_i].annotation)
+            converter = self.get_converter(param.annotation)
 
-            if params[arg_i].kind is inspect.Parameter.KEYWORD_ONLY:
-                converter = _ConsumeRestConverter(converter, params[arg_i].name)
-            elif params[arg_i].kind is inspect.Parameter.VAR_POSITIONAL:
+            if param.kind is inspect.Parameter.KEYWORD_ONLY:
+                converter = _ConsumeRestConverter(converter, param.name)
+            elif param.kind is inspect.Parameter.VAR_POSITIONAL:
                 converter = _GreedyConverter(converter)
 
-            if params[arg_i].default is not inspect.Parameter.empty and not isinstance(converter, _DefaultingConverter):
-                converter = _DefaultingConverter(converter, params[arg_i].default)
+            if param.default is not inspect.Parameter.empty:
+                if not isinstance(converter, _DefaultingConverter):
+                    converter = _DefaultingConverter(converter, param.default)
+                else:
+                    converter.default = param.default
 
             arg_converters.append(converter)
         return arg_converters

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -156,7 +156,7 @@ class SignatureInspector:
 
         if origin is typing.Union:
             if args[1] is type(None):
-                return _DefaultingConverter(self.get_converter(args[0]), None)
+                return _DefaultingConverter(self.get_converter(args[0]), None, raise_on_fail=False)
             args = [self.get_converter(conv) for conv in args]
             return _UnionConverter(*args)
 

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -514,6 +514,10 @@ class _UnionConverter:
             try:
                 converted_arg = await converter.convert(context, " ".join(args), parse=False)
                 converted = True
+
+                if getattr(converter, "conversion_func", None) is type(None):
+                    remainder = converted_arg[1]
+
                 break
             except (ValueError, TypeError, errors.ConverterFailure):
                 continue

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -540,9 +540,6 @@ class _GreedyConverter:
             except Exception:
                 break
 
-        if not converted and not self.unpack:
-            raise errors.ConverterFailure
-
         return converted, prev
 
 

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Lightbulb. If not, see <https://www.gnu.org/licenses/>.
 """
+.. _converters:
+
 Lightbulb will attempt to convert command arguments using the type or function specified by the type
 hints of each argument. By default, any types that can be converted to from a string are supported - eg int or
 float.

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -441,8 +441,9 @@ class _Converter:
         if parse:
             sv = stringview.StringView(arg_string)
             args, remainder = sv.deconstruct_str(max_parse=1)
+            args = " ".join(args)
 
-        converted_arg = await utils.maybe_await(self.conversion_func, WrappedArg(" ".join(args), context))
+        converted_arg = await utils.maybe_await(self.conversion_func, WrappedArg(args, context))
         return converted_arg, remainder
 
 
@@ -461,6 +462,7 @@ class _UnionConverter:
             try:
                 converted_arg, _ = await converter.convert(context, " ".join(args), parse=False)
                 converted = True
+                break
             except (ValueError, TypeError, errors.ConverterFailure):
                 continue
 
@@ -522,7 +524,7 @@ class _ConsumeRestConverter:
         self.param_name = param_name
 
     async def convert(self, context: context_.Context, arg_string: str):
-        converted_arg = await self.converter.convert(context, arg_string, parse=False)
+        converted_arg, _ = await self.converter.convert(context, arg_string, parse=False)
         return {self.param_name: converted_arg}, ""
 
 

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -519,7 +519,7 @@ class _UnionConverter:
                     remainder = converted_arg[1]
 
                 break
-            except (ValueError, TypeError, errors.ConverterFailure):
+            except Exception:
                 continue
 
         if not converted:
@@ -551,7 +551,7 @@ class _GreedyConverter:
                 converted_arg = await self.converter.convert(context, " ".join(args), parse=False)
                 converted.append(converted_arg[0])
                 prev = remainder
-            except (ValueError, TypeError, errors.ConverterFailure):
+            except Exception:
                 break
 
         return converted, prev

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -540,6 +540,9 @@ class _GreedyConverter:
             except Exception:
                 break
 
+        if not converted and not self.unpack:
+            raise errors.ConverterFailure
+
         return converted, prev
 
 

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -61,15 +61,6 @@ along with the converters they 'replace' can be seen below:
 .. warning:: If you use ``from __future__ import annotations`` then you **will not** be able to use converters
     in your commands. Instead of converting the arguments, the raw, unconverted arguments will be passed back
     to the command.
-
-.. error:: In the current state, var positional arguments **are not** supported. To achieve the same functionality
-    you should use an argument with the :obj:`~.Greedy` converter as seen below
-    ::
-
-        @bot.command()
-        async def foo(ctx, arg: lightbulb.Greedy[str]):
-            ....
-
 """
 from __future__ import annotations
 

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -514,10 +514,11 @@ class _UnionConverter:
 
 
 class _GreedyConverter:
-    __slots__ = ("converter",)
+    __slots__ = ("converter", "unpack")
 
-    def __init__(self, converter: _Converter) -> None:
+    def __init__(self, converter: _Converter, unpack: bool = False) -> None:
         self.converter = converter
+        self.unpack = unpack
 
     async def convert(self, context: context_.Context, arg_string: str) -> typing.Tuple[typing.List[T], str]:
         prev = arg_string

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -36,6 +36,24 @@ You can also write your own converters. A converter can be any callable and shou
 will be an instance of the :obj:`~lightbulb.converters.WrappedArg` class. The arg value and command invocation
 context can be accessed through this instance from the attributes ``data`` and ``context`` respectively.
 
+Hikari classes are also available as type hints in place of the lightbulb converters and will be internally
+converted into the necessary converter for the command to behave as expected. A list of all available classes
+along with the converters they 'replace' can be seen below:
+
+- :obj:`hikari.User` (:obj:`~.user_converter`)
+- :obj:`hikari.Member` (:obj:`~.member_converter`)
+- :obj:`hikari.TextChannel` (:obj:`~.text_channel_converter`)
+- :obj:`hikari.GuildVoiceChannel` (:obj:`~.guild_voice_channel_converter`)
+- :obj:`hikari.GuildCategory` (:obj:`~.category_converter`)
+- :obj:`hikari.Role` (:obj:`~.role_converter`)
+- :obj:`hikari.Emoji` (:obj:`~.emoji_converter`)
+- :obj:`hikari.GuildPreview` (:obj:`~.guild_converter`)
+- :obj:`hikari.Message` (:obj:`~.message_converter`)
+- :obj:`hikari.Invite` (:obj:`~.invite_converter`)
+- :obj:`hikari.Colour` (:obj:`~.colour_converter`)
+- :obj:`hikari.Color` (:obj:`~.color_converter`)
+
+
 .. warning:: For the supplied converters, some functionality will not be possible depending on the intents and/or
     cache settings of your bot application and object. If the bot does not have a cache then the converters can
     only work for arguments of ID or mention and **not** any form of name.
@@ -43,6 +61,15 @@ context can be accessed through this instance from the attributes ``data`` and `
 .. warning:: If you use ``from __future__ import annotations`` then you **will not** be able to use converters
     in your commands. Instead of converting the arguments, the raw, unconverted arguments will be passed back
     to the command.
+
+.. error:: In the current state, var positional arguments **are not** supported. To achieve the same functionality
+    you should use an argument with the :obj:`~.Greedy` converter as seen below
+    ::
+
+        @bot.command()
+        async def foo(ctx, arg: lightbulb.Greedy[str]):
+            ....
+
 """
 from __future__ import annotations
 
@@ -72,8 +99,8 @@ import hikari
 
 from lightbulb import context as context_
 from lightbulb import errors
-from lightbulb import utils
 from lightbulb import stringview
+from lightbulb import utils
 
 T = typing.TypeVar("T")
 
@@ -421,12 +448,26 @@ async def color_converter(arg: WrappedArg) -> hikari.Color:
 
 
 class Greedy(typing.Generic[T]):
+    """
+    A special converter that greedily consumes arguments until it either runs out of arguments, or a parser error
+    is encountered. Due to this behaviour, most input errors will be silently ignored.
+
+    Example:
+
+        .. code-block:: python
+
+            @bot.command()
+            async def foo(ctx, foo: Greedy[int]):
+                # if called with <p>foo 1 2 3 4 5
+                # then the arg foo would contain [1, 2, 3, 4, 5]
+                ...
+    """
+
     pass
 
 
 _converter_T = typing.Union[
-    typing.Callable[[WrappedArg], T],
-    typing.Callable[[WrappedArg], typing.Coroutine[None, None, T]]
+    typing.Callable[[WrappedArg], T], typing.Callable[[WrappedArg], typing.Coroutine[None, None, T]]
 ]
 
 

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -580,21 +580,18 @@ class _DefaultingConverter:
     async def convert(
         self, context: context_.Context, arg_string: str, *, parse: bool = False
     ) -> typing.Tuple[typing.Union[dict, T], str]:
-        sv = stringview.StringView(arg_string)
-        args, remainder = sv.deconstruct_str(max_parse=1)
-
-        if not args:
+        if not arg_string:
             return self.default, ""
 
         try:
-            converted_arg = await self.converter.convert(context, " ".join(args), parse=False)
+            converted_arg = await self.converter.convert(context, arg_string, parse=True)
         except Exception:
             if self.raise_on_fail:
                 raise
 
             return self.default, arg_string
 
-        return converted_arg[0], remainder
+        return converted_arg
 
 
 class _ConsumeRestConverter:

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -541,11 +541,12 @@ class _GreedyConverter:
 
 
 class _DefaultingConverter:
-    __slots__ = ("converter", "default")
+    __slots__ = ("converter", "default", "raise_on_fail")
 
-    def __init__(self, converter: _Converter, default: typing.Any):
+    def __init__(self, converter: _Converter, default: typing.Any, raise_on_fail: bool = True):
         self.converter = converter
         self.default = default
+        self.raise_on_fail = raise_on_fail
 
     async def convert(self, context: context_.Context, arg_string: str) -> typing.Tuple[T, str]:
         sv = stringview.StringView(arg_string)
@@ -557,6 +558,9 @@ class _DefaultingConverter:
         try:
             converted_arg, _ = await self.converter.convert(context, " ".join(args), parse=False)
         except (ValueError, TypeError, errors.ConverterFailure):
+            if self.raise_on_fail:
+                raise
+
             return self.default, arg_string
 
         return converted_arg, remainder

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -492,7 +492,7 @@ class _Converter:
         if self.conversion_func is not type(None):
             arguments.append(WrappedArg(args, context))
         else:
-            remainder = arg_string
+            remainder = args
 
         converted_arg = await utils.maybe_await(self.conversion_func, *arguments)
         return converted_arg, remainder

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -553,7 +553,11 @@ class _DefaultingConverter:
         if not args:
             return self.default, ""
 
-        converted_arg, _ = await self.converter.convert(context, " ".join(args), parse=False)
+        try:
+            converted_arg, _ = await self.converter.convert(context, " ".join(args), parse=False)
+        except (ValueError, TypeError, errors.ConverterFailure):
+            return self.default, arg_string
+
         return converted_arg, remainder
 
 

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -489,7 +489,7 @@ class _Converter:
             args = " ".join(parsed)
 
         arguments = []
-        if self.conversion_func is not type(None):
+        if self.conversion_func is not None.__class__:
             arguments.append(WrappedArg(args, context))
         else:
             remainder = args
@@ -515,7 +515,7 @@ class _UnionConverter:
                 converted_arg = await converter.convert(context, " ".join(args), parse=False)
                 converted = True
 
-                if getattr(converter, "conversion_func", None) is type(None):
+                if getattr(converter, "conversion_func", None) is None.__class__:
                     remainder = converted_arg[1]
 
                 break

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -471,9 +471,7 @@ class _ConverterT(typing.Protocol[T_co]):
 
 
 class _BaseConverter(typing.Protocol[T_co]):
-    async def convert(
-        self, context: context_.Context, arg_string: str, *, parse: bool
-    ) -> typing.Tuple[typing.Union[T_co, typing.List[T_co]], str]:
+    async def convert(self, context: context_.Context, arg_string: str, *, parse: bool) -> typing.Tuple[T_co, str]:
         ...
 
 
@@ -574,8 +572,8 @@ class _DefaultingConverter:
 
             return self.default, ""
 
-        converted_arg, _ = await self.converter.convert(context, " ".join(args), parse=False)
-        return converted_arg, remainder
+        converted_arg = await self.converter.convert(context, " ".join(args), parse=False)
+        return converted_arg[0], remainder
 
 
 class _ConsumeRestConverter:

--- a/lightbulb/cooldowns.py
+++ b/lightbulb/cooldowns.py
@@ -322,7 +322,7 @@ def dynamic_cooldown(
             @bot.command()
             async def ping(ctx):
                 await ctx.respond("Pong!")
-        This would make it so that owners bypass the cooldown and general user can only use the ``ping`` command once every ten seconds.
+        This would make it so that owners bypass the cooldown and general users can only use the ``ping`` command once every ten seconds.
     """
 
     def decorate(command: commands.Command) -> commands.Command:

--- a/lightbulb/cooldowns.py
+++ b/lightbulb/cooldowns.py
@@ -213,7 +213,7 @@ class CooldownManager:
         """Mapping of a hashable to a :obj:`~Bucket` representing the currently stored cooldowns."""
 
     async def _get_bucket(self, context: context_.Context) -> Bucket:
-        if not self.callback:
+        if not hasattr(self, "callback"):
             return self.bucket(self.length, self.usages)
 
         bucket = await utils.maybe_await(self.callback, context)

--- a/lightbulb/cooldowns.py
+++ b/lightbulb/cooldowns.py
@@ -308,7 +308,7 @@ def dynamic_cooldown(
     """
     Decorator which adds a more customized cooldown to a command.
     Args:
-        callback (Callable[[ :obj:`~Context` ], :obj: `~Bucket`]): The callback that takes a Context object and returns a Bucket object.
+        callback (Callable[[ :obj:`~Context` ], :obj:`~Bucket`]): The callback that takes a Context object and returns a Bucket object.
     Keyword Args:
         manager_cls (Type[ :obj:`~CooldownManager` ]): The **uninstantiated** class to use as the command's
             cooldown manager. Defaults to :obj:`~CooldownManager`.

--- a/lightbulb/cooldowns.py
+++ b/lightbulb/cooldowns.py
@@ -284,10 +284,12 @@ def cooldown(
             cooldown manager. Defaults to :obj:`~CooldownManager`.
     Example:
         .. code-block:: python
+
             @lightbulb.cooldown(10, 1, lightbulb.UserBucket)
             @bot.command()
             async def ping(ctx):
                 await ctx.respond("Pong!")
+
         This would make it so that each user can only use the ``ping`` command once every ten seconds.
     """
 
@@ -312,6 +314,7 @@ def dynamic_cooldown(
             cooldown manager. Defaults to :obj:`~CooldownManager`.
     Example:
         .. code-block:: python
+
             def callback(ctx):
                 if ctx.author.id in ctx.bot.owner_ids:
                     return lightbulb.UserBucket(0, 1)
@@ -322,6 +325,7 @@ def dynamic_cooldown(
             @bot.command()
             async def ping(ctx):
                 await ctx.respond("Pong!")
+
         This would make it so that owners bypass the cooldown and general users can only use the ``ping`` command once every ten seconds.
     """
 

--- a/lightbulb/errors.py
+++ b/lightbulb/errors.py
@@ -316,6 +316,17 @@ class BotMissingRequiredPermission(CheckFailure):
         """Permission(s) the bot is missing."""
 
 
+class MissingRequiredAttachment(CheckFailure):
+    """
+    Error raised when the command invocation message is missing an attachment, or an
+    attachment with the correct file extension.
+    """
+
+    def __init__(self, text) -> None:
+        self.text: str = text
+        """The error text."""
+
+
 class CommandInvocationError(CommandError):
     """
     Error raised if an error is encountered during command invocation. This will only be raised

--- a/lightbulb/errors.py
+++ b/lightbulb/errors.py
@@ -179,6 +179,28 @@ class UnclosedQuotes(CommandSyntaxError):
         """The text that caused the error to be raised."""
 
 
+class UnexpectedQuotes(CommandSyntaxError):
+    """
+    Error raised when a quote mark is found in non-quoted string.
+    """
+
+    def __init__(self, quote: str) -> None:
+        super().__init__()
+        self.quote = quote
+        """The quote mark that caused the error to be raised."""
+
+
+class ExpectedSpaces(CommandSyntaxError):
+    """
+    Error raised when no spaces found in the end of a quoted string
+    """
+
+    def __init__(self, char: str) -> None:
+        super().__init__()
+        self.char = char
+        """The character that's expected to be a space character"""
+
+
 class CheckFailure(CommandError):
     """
     Base error that is raised when a check fails for a command. Anything raised by a check

--- a/lightbulb/errors.py
+++ b/lightbulb/errors.py
@@ -43,6 +43,7 @@ __all__: typing.Final[typing.List[str]] = [
     "MissingRequiredRole",
     "MissingRequiredPermission",
     "BotMissingRequiredPermission",
+    "MissingRequiredAttachment",
     "CommandInvocationError",
 ]
 

--- a/lightbulb/help.py
+++ b/lightbulb/help.py
@@ -67,7 +67,7 @@ def get_command_signature(command: commands.Command) -> str:
     """
     Get the command signature (usage) for a command or command group.
     The signature is returned in the format:
-    ``<command name> <required arg> [optional arg] (consume rest arg...)``
+    ``<command name> <required arg> [optional arg]``
 
     Args:
         command (:obj:`~.commands.Command`): The command or group to get the signature for.

--- a/lightbulb/help.py
+++ b/lightbulb/help.py
@@ -31,7 +31,8 @@ from lightbulb import commands
 from lightbulb import errors
 from lightbulb import plugins
 from lightbulb import utils
-from lightbulb.converters import _DefaultingConverter, _ConsumeRestConverter
+from lightbulb.converters import _ConsumeRestConverter
+from lightbulb.converters import _DefaultingConverter
 
 if typing.TYPE_CHECKING:
     from lightbulb import command_handler

--- a/lightbulb/utils/nav.py
+++ b/lightbulb/utils/nav.py
@@ -142,7 +142,7 @@ class Navigator(abc.ABC, typing.Generic[T]):
                 raise TypeError("Buttons must be an instance of NavButton")
 
         if len(self.pages) == 1 and not buttons:
-            self.buttons = [NavButton("\N{BLACK SQUARE FOR STOP}", stop)]
+            self.buttons = [NavButton("\N{BLACK SQUARE FOR STOP}\N{VARIATION SELECTOR-16}", stop)]
         else:
             self.buttons: typing.Sequence[NavButton] = buttons if buttons is not None else self.create_default_buttons()
 
@@ -162,11 +162,11 @@ class Navigator(abc.ABC, typing.Generic[T]):
 
     def create_default_buttons(self) -> typing.Sequence[NavButton]:
         buttons = (
-            NavButton("\N{BLACK LEFT-POINTING DOUBLE TRIANGLE WITH VERTICAL BAR}", first_page),
-            NavButton("\N{BLACK LEFT-POINTING TRIANGLE}", prev_page),
-            NavButton("\N{BLACK SQUARE FOR STOP}", stop),
-            NavButton("\N{BLACK RIGHT-POINTING TRIANGLE}", next_page),
-            NavButton("\N{BLACK RIGHT-POINTING DOUBLE TRIANGLE WITH VERTICAL BAR}", last_page),
+            NavButton("\N{BLACK LEFT-POINTING DOUBLE TRIANGLE WITH VERTICAL BAR}\N{VARIATION SELECTOR-16}", first_page),
+            NavButton("\N{BLACK LEFT-POINTING TRIANGLE}\N{VARIATION SELECTOR-16}", prev_page),
+            NavButton("\N{BLACK SQUARE FOR STOP}\N{VARIATION SELECTOR-16}", stop),
+            NavButton("\N{BLACK RIGHT-POINTING TRIANGLE}\N{VARIATION SELECTOR-16}", next_page),
+            NavButton("\N{BLACK RIGHT-POINTING DOUBLE TRIANGLE WITH VERTICAL BAR}\N{VARIATION SELECTOR-16}", last_page),
         )
         return buttons
 
@@ -242,15 +242,15 @@ class StringNavigator(Navigator[str]):
 
     Default buttons:
 
-    - ``\\N{BLACK LEFT-POINTING DOUBLE TRIANGLE WITH VERTICAL BAR}`` (Go to first page)
+    - ``\\N{BLACK LEFT-POINTING DOUBLE TRIANGLE WITH VERTICAL BAR}\\N{VARIATION SELECTOR-16}`` (Go to first page)
 
-    - ``\\N{BLACK LEFT-POINTING TRIANGLE}`` (Go to previous page)
+    - ``\\N{BLACK LEFT-POINTING TRIANGLE}\\N{VARIATION SELECTOR-16}`` (Go to previous page)
 
-    - ``\\N{BLACK SQUARE FOR STOP}`` (Stop navigation)
+    - ``\\N{BLACK SQUARE FOR STOP}\\N{VARIATION SELECTOR-16}`` (Stop navigation)
 
-    - ``\\N{BLACK RIGHT-POINTING TRIANGLE}`` (Go to next page)
+    - ``\\N{BLACK RIGHT-POINTING TRIANGLE}\\N{VARIATION SELECTOR-16}`` (Go to next page)
 
-    - ``\\N{BLACK RIGHT-POINTING DOUBLE TRIANGLE WITH VERTICAL BAR}`` (Go to last page)
+    - ``\\N{BLACK RIGHT-POINTING DOUBLE TRIANGLE WITH VERTICAL BAR}\\N{VARIATION SELECTOR-16}`` (Go to last page)
 
     Args:
         pages (Sequence[ :obj:`str` ]): Pages to navigate through.

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -8,11 +8,14 @@ def assert_converters_recursively(
     converter: typing.Optional[converters._BaseConverter],
     types: typing.Sequence[typing.Type[converters._BaseConverter]],
     idx: int = 0,
+    *,
+    default: typing.Any,
 ) -> None:
     if converter is None:
         return
 
     assert isinstance(converter, types[idx])
+    assert getattr(converter, "_default", default) is default
 
     try:
         return getattr(converter, "converter", None)
@@ -30,10 +33,10 @@ async def union_test2(ctx, test_arg: typing.Optional[int] = 1):
     ...
 
 
-@pytest.mark.parametrize("command", [union_test1, union_test2])
-def test_has_union_converter_wrapped_in_defaulting_converter(command):
+@pytest.mark.parametrize("command, default", [(union_test1, None), (union_test2, 1)])
+def test_has_union_converter_wrapped_in_defaulting_converter(command, default):
     converter_types = [converters._DefaultingConverter, converters._UnionConverter]
-    assert_converters_recursively(command.arg_details.converters[0], converter_types)
+    assert_converters_recursively(command.arg_details.converters[0], converter_types, default=default)
 
 
 def test_has_union_converter_wrapped_in_consume_rest_converter_in_defaulting_converter():
@@ -47,7 +50,7 @@ def test_has_union_converter_wrapped_in_consume_rest_converter_in_defaulting_con
         converters._DefaultingConverter,
         converters._UnionConverter,
     ]
-    assert_converters_recursively(test.arg_details.converters[0], converter_types)
+    assert_converters_recursively(test.arg_details.converters[0], converter_types, default=1)
 
 
 def test_has_consume_rest_converter():
@@ -64,7 +67,7 @@ def test_has_defaulting_converter():
         ...
 
     converter_types = [converters._DefaultingConverter, converters._ConsumeRestConverter]
-    assert_converters_recursively(test.arg_details.converters[0], converter_types)
+    assert_converters_recursively(test.arg_details.converters[0], converter_types, default="test")
 
 
 @commands.command()

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1,0 +1,66 @@
+import typing
+
+import pytest
+from lightbulb import commands, converters
+
+
+def test_has_union_converter():
+    @commands.command()
+    async def test(ctx, test_arg: typing.Optional[int]):
+        ...
+
+    assert isinstance(test.arg_details.converters[0], converters._UnionConverter)
+
+
+def test_has_union_converter_wrapped_in_defaulting_converter():
+    @commands.command()
+    async def test(ctx, test_arg: typing.Optional[int] = 1):
+        ...
+
+    converter = test.arg_details.converters[0]
+    assert isinstance(converter, converters._DefaultingConverter)
+    assert isinstance(converter.converter, converters._UnionConverter)
+
+
+def test_has_union_converter_wrapped_in_consume_rest_converter_in_defaulting_converter():
+    @commands.command()
+    async def test(ctx, *, test_arg: typing.Optional[int] = 1):
+        ...
+
+    converter = test.arg_details.converters[0]
+    assert isinstance(converter, converters._DefaultingConverter)
+    assert isinstance(converter.converter, converters._ConsumeRestConverter)
+    assert isinstance(converter.converter.converter, converters._UnionConverter)
+
+
+def test_has_consume_rest_converter():
+    @commands.command()
+    async def test(ctx, *, test_arg: str):
+        ...
+
+    assert isinstance(test.arg_details.converters[0], converters._ConsumeRestConverter)
+
+
+def test_has_defaulting_converter():
+    @commands.command()
+    async def test(ctx, *, test_arg: str = "test"):
+        ...
+
+    converter = test.arg_details.converters[0]
+    assert isinstance(converter, converters._DefaultingConverter)
+    assert isinstance(converter.converter, converters._ConsumeRestConverter)
+
+
+@commands.command()
+async def greedy_test1(ctx, *test_arg: int):
+    ...
+
+
+@commands.command()
+async def greedy_test2(ctx, test_arg: converters.Greedy[int]):
+    ...
+
+
+@pytest.mark.parametrize("command", [greedy_test1, greedy_test2])
+def test_has_greedy_converter(command):
+    assert isinstance(command.arg_details.converters[0], converters._GreedyConverter)

--- a/tests/test_stringview.py
+++ b/tests/test_stringview.py
@@ -26,9 +26,10 @@ def test_stringview_splits_normal_args():
     assert sv.deconstruct_str() == (["I", "am", "thommo"], "")
 
 
-def test_stringview_splits_quoted_args():
-    sv = stringview.StringView('I "am thommo"')
-    assert sv.deconstruct_str() == (["I", "am thommo"], "")
+@pytest.mark.parametrize("text", ['I "am" thommo', "I 「am」 thommo"])
+def test_stringview_splits_quoted_args(text):
+    sv = stringview.StringView(text)
+    assert sv.deconstruct_str() == (["I", "am", "thommo"], "")
 
 
 def test_stringview_raises_UnclosedQuotes():
@@ -36,3 +37,17 @@ def test_stringview_raises_UnclosedQuotes():
     with pytest.raises(errors.UnclosedQuotes) as exc_info:
         sv.deconstruct_str()
     assert exc_info.type is errors.UnclosedQuotes
+
+
+def test_stringview_raises_UnexpectedQuotes():
+    sv = stringview.StringView('I"am" thommo')
+    with pytest.raises(errors.UnexpectedQuotes) as exc_info:
+        sv.deconstruct_str()
+    assert exc_info.type is errors.UnexpectedQuotes
+
+
+def test_stringview_raises_ExpectedSpaces():
+    sv = stringview.StringView('I "am"thommo')
+    with pytest.raises(errors.ExpectedSpaces) as exc_info:
+        sv.deconstruct_str()
+    assert exc_info.type is errors.ExpectedSpaces


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

Allows dynamic cooldown callbacks to return `None` in case nothing is to be applied for the given context.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
#67 