### PR TITLE
Sort prefixes by length in _resolve_prefix

### DIFF
--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -738,6 +738,8 @@ class Bot(hikari.GatewayBot):
 
         if isinstance(prefixes, str):
             prefixes = [prefixes]
+            
+        prefixes.sort(key=len, reverse=True)
 
         prefix = None
         for p in prefixes:

--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -747,8 +747,8 @@ class Bot(hikari.GatewayBot):
 
         if self.insensitive_prefix:
             for prefix in prefixes:
-                if message.content.lower().startswith(prefix.lower()):
-                    return prefix
+                if (content := message.content).lower().startswith(prefix.lower()):
+                    return content[:len(prefix)]
             return None
 
         for prefix in prefixes:

--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -124,6 +124,8 @@ class Bot(hikari.GatewayBot):
             a prefix or iterable of prefixes.
         insensitive_commands (:obj:`bool`): Whether or not commands should be case-insensitive or not.
             Defaults to False (commands are case-sensitive).
+        insensitive_prefix (:obj:`bool`): Whether or not prefixes should be handled as case-insensitive or not.
+            Defaults to False (prefixes are case-sensitive).
         ignore_bots (:obj:`bool`): Ignore other bot's messages invoking your bot's commands if True (default), else not.
             invoked by other bots. Defaults to ``True``.
         owner_ids (List[ :obj:`int` ]): IDs that the bot should treat as owning the bot.
@@ -138,6 +140,7 @@ class Bot(hikari.GatewayBot):
         *,
         prefix,
         insensitive_commands: bool = False,
+        insensitive_prefix: bool = False,
         ignore_bots: bool = True,
         owner_ids: typing.Iterable[int] = (),
         help_class: typing.Type[help_.HelpCommand] = help_.HelpCommand,
@@ -157,6 +160,7 @@ class Bot(hikari.GatewayBot):
         self.owner_ids: typing.Iterable[int] = owner_ids
         """Iterable of the bot's owner IDs. This can be set by :meth:`Bot.fetch_owner_ids` if not given in the constructor."""
         self.insensitive_commands = insensitive_commands
+        self.insensitive_prefix = insensitive_prefix
         self.extensions: typing.List[str] = []
         """A list of extensions currently loaded to the bot."""
         self.plugins: typing.MutableMapping[str, plugins.Plugin] = {}
@@ -740,6 +744,12 @@ class Bot(hikari.GatewayBot):
             prefixes = [prefixes]
             
         prefixes.sort(key=len, reverse=True)
+
+        if self.insensitive_prefix:
+            for prefix in prefixes:
+                if message.content.lower().startswith(prefix.lower()):
+                    return prefix
+            return None
 
         for prefix in prefixes:
             if message.content.startswith(prefix):

--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -741,12 +741,10 @@ class Bot(hikari.GatewayBot):
             
         prefixes.sort(key=len, reverse=True)
 
-        prefix = None
-        for p in prefixes:
-            if message.content.startswith(p):
-                prefix = p
-                break
-        return prefix
+        for prefix in prefixes:
+            if message.content.startswith(prefix):
+                return prefix
+        return None
 
     def _validate_command_exists(self, invoked_with) -> commands.Command:
         if (command := self.get_command(invoked_with)) is not None:

--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -124,8 +124,6 @@ class Bot(hikari.GatewayBot):
             a prefix or iterable of prefixes.
         insensitive_commands (:obj:`bool`): Whether or not commands should be case-insensitive or not.
             Defaults to False (commands are case-sensitive).
-        insensitive_prefix (:obj:`bool`): Whether or not prefixes should be handled as case-insensitive or not.
-            Defaults to False (prefixes are case-sensitive).
         ignore_bots (:obj:`bool`): Ignore other bot's messages invoking your bot's commands if True (default), else not.
             invoked by other bots. Defaults to ``True``.
         owner_ids (List[ :obj:`int` ]): IDs that the bot should treat as owning the bot.
@@ -140,7 +138,6 @@ class Bot(hikari.GatewayBot):
         *,
         prefix,
         insensitive_commands: bool = False,
-        insensitive_prefix: bool = False,
         ignore_bots: bool = True,
         owner_ids: typing.Iterable[int] = (),
         help_class: typing.Type[help_.HelpCommand] = help_.HelpCommand,
@@ -160,7 +157,6 @@ class Bot(hikari.GatewayBot):
         self.owner_ids: typing.Iterable[int] = owner_ids
         """Iterable of the bot's owner IDs. This can be set by :meth:`Bot.fetch_owner_ids` if not given in the constructor."""
         self.insensitive_commands = insensitive_commands
-        self.insensitive_prefix = insensitive_prefix
         self.extensions: typing.List[str] = []
         """A list of extensions currently loaded to the bot."""
         self.plugins: typing.MutableMapping[str, plugins.Plugin] = {}
@@ -744,12 +740,6 @@ class Bot(hikari.GatewayBot):
             prefixes = [prefixes]
             
         prefixes.sort(key=len, reverse=True)
-
-        if self.insensitive_prefix:
-            for prefix in prefixes:
-                if (content := message.content).lower().startswith(prefix.lower()):
-                    return content[:len(prefix)]
-            return None
 
         for prefix in prefixes:
             if message.content.startswith(prefix):


### PR DESCRIPTION
### Summary
Make it so prefixes are sorted by reverse length order (longest first) in `_resolve_prefix`.

**The reason for this:**
If the provided prefix function returns (or string/iterable etc) 2 or more prefixes where one starts with another prefix (e.g if `["hello", "helloworld"]` was returned, `"helloworld"` starts with `"hello"`).  This means that if a user types `helloworld<command_name> <args>` then lighbulb will return `"hello"` as the prefix when the user intended for `"helloworld"` to be the prefix, therefore lightbulb will try to find a command called `world<command_name>` (resulting in no command being found) instead of just `<command_name>`. If it checked the longer prefix first, this wouldn't be an issue.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.
