### PR TITLE
Some typos

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,11 @@ If you think anything is missing, make a merge request to add it, or contact tho
 
 ----
 
+Version 1.0.1
+=============
+
+- Fixed ``AttributeError`` when using :obj:`~lightbulb.command_handler.when_mentioned_or`.
+
 Version 1.0.0
 =============
 

--- a/lightbulb/__init__.py
+++ b/lightbulb/__init__.py
@@ -53,4 +53,4 @@ __all__: typing.Final[typing.List[str]] = [
     *events.__all__,
 ]
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -78,7 +78,7 @@ def when_mentioned_or(prefix_provider):
     """
 
     async def get_prefixes(bot, message):
-        mentions = [f"<@{bot.me.id}> ", f"<@!{bot.me.id}> "]
+        mentions = [f"<@{bot.get_me().id}> ", f"<@!{bot.get_me().id}> "]
 
         if callable(prefix_provider):
             prefixes = prefix_provider(bot, message)

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -326,7 +326,7 @@ class Command:
     @property
     def qualified_name(self) -> str:
         """
-        The fully qualified name of the command, taking into  account
+        The fully qualified name of the command, taking into account
         whether or not the command is a subcommand.
 
         Returns:

--- a/lightbulb/help.py
+++ b/lightbulb/help.py
@@ -306,7 +306,7 @@ class HelpCommand:
 
         Args:
             context (:obj:`~.context.Context`): Context to send the help to.
-            command (:obj:`~.commands.Group`): Group object to send help for.
+            group (:obj:`~.commands.Group`): Group object to send help for.
 
         Returns:
             ``None``

--- a/lightbulb/plugins.py
+++ b/lightbulb/plugins.py
@@ -180,7 +180,7 @@ class Plugin:
         self.name = self.__class__.__name__ if name is None else name
         """The plugin's registered name."""
         self.commands = set()
-        """"A set containing all commands and groups registered to the plugin."""
+        """A set containing all commands and groups registered to the plugin."""
         self._commands: typing.MutableMapping[str, typing.Union[commands.Command, commands.Group]] = {}
         self.listeners: typing.MutableMapping[
             typing.Type[hikari.Event],


### PR DESCRIPTION
### Summary
Remove a double space in the docstring of `qualified_name` command property.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.