### PR TITLE
hikari.TextChannel to TextableChannel

### DIFF
--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -57,7 +57,7 @@ _ConverterT = typing.Union[_BaseConverter[T], _BaseConverter[typing.List[T]]]
 _CONVERTER_CLASS_MAPPING = {
     hikari.User: converters.user_converter,
     hikari.Member: converters.member_converter,
-    hikari.TextChannel: converters.text_channel_converter,
+    hikari.TextableChannel: converters.text_channel_converter,
     hikari.GuildVoiceChannel: converters.guild_voice_channel_converter,
     hikari.GuildCategory: converters.category_converter,
     hikari.Role: converters.role_converter,

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -601,7 +601,7 @@ class _ConsumeRestConverter:
 if typing.TYPE_CHECKING:
     user_converter = hikari.User
     member_converter = hikari.Member
-    text_channel_converter = hikari.TextChannel
+    text_channel_converter = hikari.TextableChannel
     guild_voice_channel_converter = hikari.GuildVoiceChannel
     voice_channel_converter = guild_voice_channel_converter
     category_converter = hikari.GuildCategory


### PR DESCRIPTION
### Summary
Change hikari.TextChannel to TextableChannel, im pretty sure this is the only conflict with hikari master (regardless of any mypy errors)

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
