### PR TITLE
Stop hiding cache calls behind properties

### DIFF
--- a/docs/source/slash-commands.rst
+++ b/docs/source/slash-commands.rst
@@ -11,6 +11,8 @@ Read more about this on the `discord documentation <https://discord.com/develope
 
 ----
 
+For example slash command code see the `examples directory <https://github.com/tandemdude/hikari-lightbulb/tree/development/examples>`_
+
 Creating a Basic Slash Command
 ==============================
 
@@ -29,24 +31,16 @@ Your first slash command can be written very easily:
     # Create a custom slash command class and implement
     # the abstract methods
     class Echo(slash_commands.SlashCommand):
-        @property
-        def options(self):
-            return [
-                hikari.CommandOption(
-                    name="text",
-                    description="Text to repeat",
-                    type=hikari.OptionType.STRING,
-                    is_required=True
-                ),
-            ]
-
-        @property
-        def description(self):
-            return "Repeats your input."
-
-        @property
-        def enabled_guilds(self):
-            return None
+        description = "Repeats your input."
+        enabled_guilds = None
+        options = [
+            hikari.CommandOption(
+                name="text",
+                description="Text to repeat",
+                type=hikari.OptionType.STRING,
+                is_required=True
+            ),
+        ]
 
         async def callback(self, context):
             await context.respond(context.options["text"].value)
@@ -86,31 +80,21 @@ slash command group:
 
 
     class Foo(slash_commands.SlashCommandGroup):
-        @property
-        def description(self):
-            return "Test slash command group."
-
-        @property
-        def enabled_guilds(self):
-            return None
+        description = "Test slash command group."
+        enabled_guilds = None
 
 
     @Foo.subcommand()
     class Bar(slash_commands.SlashSubCommand):
-        @property
-        def description(self):
-            return "Test subcommand."
-
-        @property
-        def options(self):
-            return [
-                hikari.CommandOption(
-                    name="baz",
-                    description="Test subcommand option.",
-                    is_required=True,
-                    type=hikari.OptionType.STRING,
-                )
-            ]
+        description = "Test subcommand."
+        options = [
+            hikari.CommandOption(
+                name="baz",
+                description="Test subcommand option.",
+                is_required=True,
+                type=hikari.OptionType.STRING,
+            )
+        ]
 
         async def callback(self, context):
             await context.respond(context.options["baz"].value)
@@ -146,9 +130,7 @@ as you may refer to the previous sections for more details.
 
     @Foo.subgroup()
     class Bar(slash_commands.SlashSubGroup):
-        @property
-        def description(self):
-            return "Test subgroup."
+        description = "Test subgroup."
 
 
     @Bar.subcommand()

--- a/docs/source/slash-commands.rst
+++ b/docs/source/slash-commands.rst
@@ -9,6 +9,8 @@ As Discord has now decided to ban bots from reading messages without the intent 
 
 Read more about this on the `discord documentation <https://discord.com/developers/docs/interactions/application-commands>`_ yourself.
 
+----
+
 Creating a Basic Slash Command
 ==============================
 
@@ -57,6 +59,8 @@ Your first slash command can be written very easily:
     # until the bot is shut off
     bot.run()
 
+
+----
 
 Creating a Slash Command Group
 ==============================
@@ -112,6 +116,8 @@ slash command group:
             await context.respond(context.options["baz"].value)
 
 
+----
+
 Creating a Slash Command Subgroup
 =================================
 
@@ -149,6 +155,8 @@ as you may refer to the previous sections for more details.
     class Baz(slash_commands.SlashSubCommand):
         ...
 
+
+----
 
 API Reference
 =============

--- a/docs/source/v1-changelog.rst
+++ b/docs/source/v1-changelog.rst
@@ -11,9 +11,11 @@ Version 1.2.0
 
 - Made the ``bot`` attribute of slash commands public.
 
-- Added :obj:`~lightbulb.slash_commands.SlashCommandContext.option_values`
+- Added :obj:`~lightbulb.slash_commands.SlashCommandContext.option_values`.
 
-- Added :obj:`~lightbulb.slash_commands.SlashCommandOptionsWrapper`
+- Added :obj:`~lightbulb.slash_commands.SlashCommandOptionsWrapper`.
+
+- Added :obj:`~lightbulb.command_handler.Bot.purge_slash_commands`.
 
 
 Version 1.1.0

--- a/docs/source/v1-changelog.rst
+++ b/docs/source/v1-changelog.rst
@@ -6,6 +6,13 @@ Below are all the changelogs for the stable versions of hikari-lightbulb (versio
 
 ----
 
+Version 1.2.1
+=============
+
+- Made the bot now only send a slash command create request to discord if it detects that the version discord holds is out of date. This can be disabled using the ``recreate_changed_slash_commands`` flag in the bot constructor.
+
+- Various documentation improvements.
+
 Version 1.2.0
 =============
 

--- a/docs/source/v1-changelog.rst
+++ b/docs/source/v1-changelog.rst
@@ -17,6 +17,8 @@ Version 1.2.0
 
 - Added :obj:`~lightbulb.command_handler.Bot.purge_slash_commands`.
 
+- Added support for calling :obj:`~lightbulb.command_handler.Bot.add_plugin` with a plugin class instead of an instance.
+
 
 Version 1.1.0
 =============

--- a/docs/source/v1-changelog.rst
+++ b/docs/source/v1-changelog.rst
@@ -19,6 +19,8 @@ Version 1.2.0
 
 - Added support for calling :obj:`~lightbulb.command_handler.Bot.add_plugin` with a plugin class instead of an instance.
 
+- Added ability for a bot to be slash commands only by passing the ``slash_commands_only`` flag into the constructor.
+
 
 Version 1.1.0
 =============

--- a/docs/source/v1-changelog.rst
+++ b/docs/source/v1-changelog.rst
@@ -6,6 +6,16 @@ Below are all the changelogs for the stable versions of hikari-lightbulb (versio
 
 ----
 
+Version 1.2.0
+=============
+
+- Made the ``bot`` attribute of slash commands public.
+
+- Added :obj:`~lightbulb.slash_commands.SlashCommandContext.option_values`
+
+- Added :obj:`~lightbulb.slash_commands.SlashCommandOptionsWrapper`
+
+
 Version 1.1.0
 =============
 

--- a/docs/source/v1-changelog.rst
+++ b/docs/source/v1-changelog.rst
@@ -21,6 +21,7 @@ Version 1.2.0
 
 - Added ability for a bot to be slash commands only by passing the ``slash_commands_only`` flag into the constructor.
 
+- Fixed ``AttributeError`` when using navigators.
 
 Version 1.1.0
 =============

--- a/examples/basic_bot_example.py
+++ b/examples/basic_bot_example.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# Copyright © Thomm.o 2021
+#
+# This file is part of Lightbulb.
+#
+# Lightbulb is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Lightbulb is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Lightbulb. If not, see <https://www.gnu.org/licenses/>.
+import lightbulb
+import hikari
+
+bot = lightbulb.Bot(prefix="!", token="YOUR_TOKEN", intents=hikari.Intents.ALL)
+
+
+@bot.listen(hikari.ShardReadyEvent)
+async def ready_listener(event):
+    print("The bot is ready!")
+
+
+@bot.command()
+async def ping(ctx):
+    """Checks that the bot is alive"""
+    await ctx.respond("Pong!")
+
+
+@bot.command()
+async def add(ctx, num1: int, num2: int):
+    """Adds the two given numbers together"""
+    await ctx.respond(f"{num1} + {num2} = {num1 + num2}")
+
+
+@bot.command()
+async def greet(ctx, user: hikari.User):
+    """Greets the specified user"""
+    await ctx.respond(f"Hello {user.mention}!")
+
+
+bot.run()

--- a/examples/basic_bot_example.py
+++ b/examples/basic_bot_example.py
@@ -15,8 +15,9 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Lightbulb. If not, see <https://www.gnu.org/licenses/>.
-import lightbulb
 import hikari
+
+import lightbulb
 
 bot = lightbulb.Bot(prefix="!", token="YOUR_TOKEN", intents=hikari.Intents.ALL)
 

--- a/examples/basic_slash_command_bot_example.py
+++ b/examples/basic_slash_command_bot_example.py
@@ -23,25 +23,19 @@ bot = lightbulb.Bot(prefix="!", token="YOUR_TOKEN", intents=hikari.Intents.ALL)
 
 
 class Ping(lightbulb.slash_commands.SlashCommand):
-    @property
-    def description(self):
-        return "Checks that the bot is alive"
+    description = "Checks that the bot is alive"
+    # None here means that the slash command is global. To enable for specific guilds,
+    # it should instead be a sequence of guild IDs.
+    enabled_guilds = None
+    options = []
 
-    @property
-    def options(self):
-        return []
-
+    # This function is called when the slash command is invoked by a user. It **must** be called "callback"
+    # otherwise the interaction **will** fail.
     async def callback(self, context):
         # To send an ephemeral message instead pass the kwarg:
         # flags=hikari.MessageFlag.EPHEMERAL
         # e.g. await context.respond("Pong!", flags=hikari.MessageFlag.EPHEMERAL)
         await context.respond("Pong!")
-
-    @property
-    def enabled_guilds(self):
-        # Returning None here means that the slash command is global.
-        # To enable for specific guilds, a sequence of guild IDs should be returned instead
-        return None
 
 
 bot.add_slash_command(Ping)

--- a/examples/basic_slash_command_bot_example.py
+++ b/examples/basic_slash_command_bot_example.py
@@ -15,8 +15,9 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Lightbulb. If not, see <https://www.gnu.org/licenses/>.
-import lightbulb
 import hikari
+
+import lightbulb
 
 bot = lightbulb.Bot(prefix="!", token="YOUR_TOKEN", intents=hikari.Intents.ALL)
 

--- a/examples/basic_slash_command_bot_example.py
+++ b/examples/basic_slash_command_bot_example.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# Copyright © Thomm.o 2021
+#
+# This file is part of Lightbulb.
+#
+# Lightbulb is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Lightbulb is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Lightbulb. If not, see <https://www.gnu.org/licenses/>.
+import lightbulb
+import hikari
+
+bot = lightbulb.Bot(prefix="!", token="YOUR_TOKEN", intents=hikari.Intents.ALL)
+
+
+class Ping(lightbulb.slash_commands.SlashCommand):
+    @property
+    def description(self):
+        return "Checks that the bot is alive"
+
+    @property
+    def options(self):
+        return []
+
+    async def callback(self, context):
+        # To send an ephemeral message instead pass the kwarg:
+        # flags=hikari.MessageFlag.EPHEMERAL
+        # e.g. await context.respond("Pong!", flags=hikari.MessageFlag.EPHEMERAL)
+        await context.respond("Pong!")
+
+    @property
+    def enabled_guilds(self):
+        # Returning None here means that the slash command is global.
+        # To enable for specific guilds, a sequence of guild IDs should be returned instead
+        return None
+
+
+bot.add_slash_command(Ping)
+bot.run()

--- a/examples/extension_example.py
+++ b/examples/extension_example.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+# Copyright © Thomm.o 2021
+#
+# This file is part of Lightbulb.
+#
+# Lightbulb is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Lightbulb is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Lightbulb. If not, see <https://www.gnu.org/licenses/>.
+import lightbulb
+
+
+class ExamplePlugin(lightbulb.Plugin):
+    @lightbulb.command()
+    async def ping(self, ctx):
+        """Checks that the bot is alive"""
+        await ctx.respond("Pong!")
+
+
+class ExampleSlashCommand(lightbulb.slash_commands.SlashCommand):
+    @property
+    def name(self):
+        return "ping"
+
+    @property
+    def description(self):
+        return "Checks that the bot is alive"
+
+    @property
+    def options(self):
+        return []
+
+    @property
+    def enabled_guilds(self):
+        return None
+
+    async def callback(self, context) -> None:
+        await context.respond("Pong!")
+
+
+def load(bot):
+    bot.add_plugin(ExamplePlugin())
+    bot.add_slash_command(ExampleSlashCommand)
+
+
+def unload(bot):
+    bot.remove_plugin("ExamplePlugin")
+    # Name passed in here must be the name of the slash command
+    # as discord sees it. So "ping" in the above example, not "exampleslashcommand"
+    bot.remove_slash_command("ping")

--- a/examples/extension_example.py
+++ b/examples/extension_example.py
@@ -26,21 +26,10 @@ class ExamplePlugin(lightbulb.Plugin):
 
 
 class ExampleSlashCommand(lightbulb.slash_commands.SlashCommand):
-    @property
-    def name(self):
-        return "ping"
-
-    @property
-    def description(self):
-        return "Checks that the bot is alive"
-
-    @property
-    def options(self):
-        return []
-
-    @property
-    def enabled_guilds(self):
-        return None
+    name = "ping"
+    description = "Checks that the bot is alive"
+    enabled_guilds = None
+    options = []
 
     async def callback(self, context) -> None:
         await context.respond("Pong!")

--- a/examples/plugin_example.py
+++ b/examples/plugin_example.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# Copyright © Thomm.o 2021
+#
+# This file is part of Lightbulb.
+#
+# Lightbulb is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Lightbulb is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Lightbulb. If not, see <https://www.gnu.org/licenses/>.
+import lightbulb
+import hikari
+
+bot = lightbulb.Bot(prefix="!", token="YOUR_TOKEN", intents=hikari.Intents.ALL)
+
+
+class ExamplePlugin(lightbulb.Plugin):
+    @lightbulb.command()
+    async def ping(self, ctx):
+        """Checks that the bot is alive"""
+        await ctx.respond("Pong!")
+
+
+bot.add_plugin(ExamplePlugin())
+bot.run()

--- a/examples/plugin_example.py
+++ b/examples/plugin_example.py
@@ -15,8 +15,9 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Lightbulb. If not, see <https://www.gnu.org/licenses/>.
-import lightbulb
 import hikari
+
+import lightbulb
 
 bot = lightbulb.Bot(prefix="!", token="YOUR_TOKEN", intents=hikari.Intents.ALL)
 

--- a/lightbulb/__init__.py
+++ b/lightbulb/__init__.py
@@ -54,4 +54,4 @@ __all__: typing.Final[typing.List[str]] = [
     *events.__all__,
 ]
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"

--- a/lightbulb/__init__.py
+++ b/lightbulb/__init__.py
@@ -54,4 +54,4 @@ __all__: typing.Final[typing.List[str]] = [
     *events.__all__,
 ]
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -135,22 +135,31 @@ class Bot(hikari.GatewayBot):
             bot starts. This will remove any slash commands that do not have a
             :obj:`~lightbulb.slash_commands.SlashCommand` object bound to them when the bot starts but are registered
             according to  discord's API. Defaults to ``True``
+        slash_commands_only (:obj:`bool`): Whether or not the bot will only be using slash commands to interact
+            with discord. Defaults to ``False``. If this is ``False`` and no prefix is provided then an error will
+            be raised. If ``True``, then you do not need to provide a prefix.
         **kwargs: Other parameters passed to the :class:`hikari.impl.bot.BotAppImpl` constructor.
     """
 
     def __init__(
         self,
         *,
-        prefix,
+        prefix=None,
         insensitive_commands: bool = False,
         ignore_bots: bool = True,
         owner_ids: typing.Iterable[int] = (),
         help_class: typing.Type[help_.HelpCommand] = help_.HelpCommand,
         delete_unbound_slash_commands: bool = True,
+        slash_commands_only: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
-        self.subscribe(hikari.MessageCreateEvent, self.handle)
+
+        if prefix is None and slash_commands_only is False:
+            raise TypeError("slash_commands_only is False but no prefix was provided.")
+
+        if not slash_commands_only:
+            self.subscribe(hikari.MessageCreateEvent, self.handle)
         self.subscribe(hikari.InteractionCreateEvent, self.handle_slash_commands)
         self.subscribe(hikari.StartingEvent, self._manage_slash_commands)
 

--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -998,6 +998,8 @@ class Bot(hikari.GatewayBot):
         Returns:
             Optional[ :obj:`str` ]: Name of the slash command that was removed.
         """
+        name = name.lower()
+
         cmd = self._slash_commands.pop(name)
         if cmd is not None:
             self.slash_commands.remove(cmd)

--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -412,12 +412,16 @@ class Bot(hikari.GatewayBot):
         """
         self._checks.append(func)
 
-    def add_plugin(self, plugin: plugins.Plugin) -> None:
+    def add_plugin(self, plugin: typing.Union[plugins.Plugin, typing.Type[plugins.Plugin]]) -> None:
         """
-        Add a :obj:`~.plugins.Plugin` to the bot including all of the plugin commands.
+        Add a :obj:`~.plugins.Plugin` instance or class to the bot, including all of the plugin commands.
+
+        If a class is passed in instead of a plugin instance, then the bot will attempt to instantiate it and
+        then add the newly-created plugin instance to the bot.
 
         Args:
-            plugin (:obj:`~.plugins.Plugin`): Plugin to add to the bot.
+            plugin (Union[:obj:`~.plugins.Plugin`, Type[:obj:`~.plugins.Plugin`]]): Plugin instance or plugin
+                subclass to add to the bot.
 
         Returns:
             ``None``
@@ -426,6 +430,9 @@ class Bot(hikari.GatewayBot):
             :obj:`NameError`: If the name of the plugin being added conflicts with an
                 existing plugin.
         """
+        if inspect.isclass(plugin) and issubclass(plugin, plugins.Plugin):
+            return self.add_plugin(plugin())
+
         if plugin.name in self.plugins:
             raise NameError(f"A plugin named {plugin.name} is already registered.")
 

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -326,7 +326,7 @@ class Command:
     @property
     def qualified_name(self) -> str:
         """
-        The fully qualified name of the command, taking into  account
+        The fully qualified name of the command, taking into account
         whether or not the command is a subcommand.
 
         Returns:

--- a/lightbulb/context.py
+++ b/lightbulb/context.py
@@ -165,8 +165,7 @@ class Context:
 
         return re.sub(r"<@!?(\d+)>", replace, self.prefix)
 
-    @property
-    def guild(self) -> typing.Optional[hikari.Guild]:
+    def get_guild(self) -> typing.Optional[hikari.Guild]:
         """
         The cached :obj:`hikari.Guild` instance for the context's guild ID.
 
@@ -177,8 +176,7 @@ class Context:
             return self.bot.cache.get_available_guild(self.guild_id)
         return None
 
-    @property
-    def channel(self) -> typing.Optional[hikari.TextableChannel]:
+    def get_channel(self) -> typing.Optional[hikari.TextableChannel]:
         """
         The cached :obj:`hikari.TextableChannel` instance for the context's channel ID.
 

--- a/lightbulb/help.py
+++ b/lightbulb/help.py
@@ -306,7 +306,7 @@ class HelpCommand:
 
         Args:
             context (:obj:`~.context.Context`): Context to send the help to.
-            command (:obj:`~.commands.Group`): Group object to send help for.
+            group (:obj:`~.commands.Group`): Group object to send help for.
 
         Returns:
             ``None``

--- a/lightbulb/plugins.py
+++ b/lightbulb/plugins.py
@@ -180,7 +180,7 @@ class Plugin:
         self.name = self.__class__.__name__ if name is None else name
         """The plugin's registered name."""
         self.commands = set()
-        """"A set containing all commands and groups registered to the plugin."""
+        """A set containing all commands and groups registered to the plugin."""
         self._commands: typing.MutableMapping[str, typing.Union[commands.Command, commands.Group]] = {}
         self.listeners: typing.MutableMapping[
             typing.Type[hikari.Event],

--- a/lightbulb/slash_commands/__init__.py
+++ b/lightbulb/slash_commands/__init__.py
@@ -15,6 +15,10 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Lightbulb. If not, see <https://www.gnu.org/licenses/>.
+"""
+.. error::
+    The implementation of slash commands within a Plugin class is not supported.
+"""
 import typing
 
 from lightbulb.slash_commands.commands import *
@@ -27,5 +31,6 @@ __all__: typing.Final[typing.List[str]] = [
     "SlashCommandGroup",
     "SlashSubGroup",
     "SlashSubCommand",
+    "SlashCommandOptionsWrapper",
     "SlashCommandContext",
 ]

--- a/lightbulb/slash_commands/commands.py
+++ b/lightbulb/slash_commands/commands.py
@@ -58,10 +58,10 @@ class SlashCommandBase(abc.ABC):
         bot (:obj:`~lightbulb.command_handler.Bot`): The bot instance the command will be added to.
     """
 
-    __slots__: typing.Sequence[str] = ("_bot", "_instances")
+    __slots__: typing.Sequence[str] = ("bot", "_instances")
 
     def __init__(self, bot: command_handler.Bot) -> None:
-        self._bot = bot
+        self.bot = bot
         self._instances: typing.MutableMapping[hikari.Snowflakeish, hikari.Command] = {}
 
     @abc.abstractmethod
@@ -130,7 +130,7 @@ class TopLevelSlashCommandBase(SlashCommandBase, abc.ABC):
         Returns:
             ``None``
         """
-        await self._bot.rest.delete_application_command(
+        await self.bot.rest.delete_application_command(
             app, self._instances[guild_id], **({"guild": guild_id} if guild_id is not None else {})
         )
         self._instances.pop(guild_id)
@@ -200,7 +200,7 @@ class SlashCommand(TopLevelSlashCommandBase, abc.ABC):
         app: hikari.SnowflakeishOr[hikari.PartialApplication],
         guild_id: typing.Optional[hikari.Snowflakeish] = None,
     ) -> hikari.Command:
-        created_command = await self._bot.rest.create_application_command(
+        created_command = await self.bot.rest.create_application_command(
             app,
             self.name,
             self.description,
@@ -403,7 +403,7 @@ class SlashCommandGroup(TopLevelSlashCommandBase, abc.ABC):
         app: hikari.SnowflakeishOr[hikari.PartialApplication],
         guild_id: typing.Optional[hikari.Snowflakeish] = None,
     ) -> hikari.Command:
-        created_command = await self._bot.rest.create_application_command(
+        created_command = await self.bot.rest.create_application_command(
             app,
             self.name,
             self.description,

--- a/lightbulb/slash_commands/commands.py
+++ b/lightbulb/slash_commands/commands.py
@@ -124,9 +124,11 @@ class TopLevelSlashCommandBase(SlashCommandBase, abc.ABC):
     ) -> None:
         """
         Deletes the command for a specific guild, or globally if no guild ID is given.
+
         Args:
             app (hikari.SnowflakeishOr[hikari.PartialApplication]): The application to delete the command from.
             guild_id (Optional[hikari.Snowflakeish]): The ID of the guild to delete the command for.
+
         Returns:
             ``None``
         """
@@ -187,7 +189,13 @@ class SlashCommand(TopLevelSlashCommandBase, abc.ABC):
     Abstract base class for top level slash commands. All slash commands that are not groups
     should inherit from this class.
 
-    All abstract methods **must** be implemented by your custom slash command class.
+    All abstract methods **must** be implemented by your custom slash command class. A list of the abstract
+    methods and properties you are required to implement for this class can be seen below:
+
+    - :obj:`~lightbulb.slash_commands.SlashCommandBase.description`
+    - :obj:`~lightbulb.slash_commands.SlashCommand.options`
+    - :obj:`~lightbulb.slash_commands.TopLevelSlashCommandBase.enabled_guilds`
+    - :obj:`~lightbulb.slash_commands.SlashCommand.callback`
     """
 
     __slots__: typing.Sequence[str] = ()
@@ -237,7 +245,12 @@ class SlashSubCommand(SlashCommandBase, abc.ABC):
     """
     Abstract base class for slash subcommands. All slash subcommands should inherit from this class.
 
-    All abstract methods **must** be implemented by your custom slash subcommand class.
+    All abstract methods **must** be implemented by your custom slash subcommand class. A list of the abstract
+    methods and properties you are required to implement for this class can be seen below:
+
+    - :obj:`~lightbulb.slash_commands.SlashCOmmandBase.description`
+    - :obj:`~lightbulb.slash_commands.SlashSubCommand.options`
+    - :obj:`~lightbulb.slash_commands.SlashSubCommand.callback`
     """
 
     async def __call__(self, context: context_.SlashCommandContext) -> None:
@@ -289,7 +302,10 @@ class SlashSubGroup(SlashCommandBase, abc.ABC):
     """
     Abstract base class for slash subgroups. All slash subgroups should inherit from this class.
 
-    All abstract methods **must** be implemented by your custom slash subgroup class.
+    All abstract methods **must** be implemented by your custom slash subgroup class. A list of the abstract
+    methods and properties you are required to implement for this class can be seen below:
+
+    - :obj:`~lightbulb.slash_commands.SlashCommandBase.description`
     """
 
     __slots__: typing.Sequence[str] = ("_subcommands",)
@@ -348,7 +364,11 @@ class SlashCommandGroup(TopLevelSlashCommandBase, abc.ABC):
     """
     Abstract base class for slash command groups. All slash command groups should inherit from this class.
 
-    All abstract methods **must** be implemented by your custom slash command group class.
+    All abstract methods **must** be implemented by your custom slash command group class. A list of the abstract
+    methods and properties you are required to implement for this class can be seen below:
+
+    - :obj:`~lightbulb.slash_commands.SlashCommandBase.description`
+    - :obj:`~lightbulb.slash_commands.TopLevelSlashCommandBase.enabled_guilds`
     """
 
     __slots__: typing.Sequence[str] = ("_subcommands",)

--- a/lightbulb/slash_commands/context.py
+++ b/lightbulb/slash_commands/context.py
@@ -62,8 +62,6 @@ class SlashCommandContext:
         command (:obj:`~lightbulb.slash_commands.SlashCommand`): The :obj:`~SlashCommand` object that was invoked.
     """
 
-    __slots__: typing.Sequence[str] = ("bot", "_interaction", "_command", "options", "arg_values")
-
     def __init__(
         self,
         bot: command_handler.Bot,

--- a/lightbulb/slash_commands/context.py
+++ b/lightbulb/slash_commands/context.py
@@ -157,6 +157,10 @@ class SlashCommandContext:
 
         Returns:
             ``None``
+
+        Note:
+            This can only be called **once** for each interaction. To add more information to the response
+            you should use :obj:`~lightbulb.slash_commands.SlashCommandContext.edit_response`
         """
         await self._interaction.create_initial_response(hikari.ResponseType.MESSAGE_CREATE, content, **kwargs)
 

--- a/lightbulb/slash_commands/context.py
+++ b/lightbulb/slash_commands/context.py
@@ -42,6 +42,7 @@ class SlashCommandOptionsWrapper:
         options (Mapping[:obj:`str`, :obj:`hikari.CommandInteractionOption`): The options that the slash command
             was called with.
     """
+
     __slots__: typing.Sequence[str] = ("_options",)
 
     def __init__(self, options: typing.Mapping[str, hikari.CommandInteractionOption]) -> None:

--- a/lightbulb/slash_commands/context.py
+++ b/lightbulb/slash_commands/context.py
@@ -126,13 +126,11 @@ class SlashCommandContext:
         """The :obj:`hikari.Command` object for this specific context."""
         return self._command.get_command(self.guild_id)
 
-    @property
-    def channel(self) -> typing.Optional[hikari.GuildChannel]:
+    def get_channel(self) -> typing.Optional[hikari.GuildChannel]:
         """The cached channel that the command was invoked in, or ``None`` if not found."""
         return self._interaction.get_channel()
 
-    @property
-    def guild(self) -> typing.Optional[hikari.GatewayGuild]:
+    def get_guild(self) -> typing.Optional[hikari.GatewayGuild]:
         """The cached guild that the command was invoked in, or ``None`` if not found."""
         return self.bot.cache.get_guild(self.guild_id)
 

--- a/lightbulb/utils/nav.py
+++ b/lightbulb/utils/nav.py
@@ -70,7 +70,9 @@ class NavButton:
         Returns:
             :obj:`bool`: Whether or not the button is pressed in the given event.
         """
-        return event.emoji.mention == self.emoji.mention
+        if event.emoji_id is not None and isinstance(self.emoji, hikari.CustomEmoji):
+            return event.emoji_id == self.emoji.id
+        return event.emoji_name == self.emoji.name
 
     def press(self, nav: Navigator, event: hikari.ReactionAddEvent) -> typing.Coroutine[typing.Any, typing.Any, None]:
         """

--- a/release_webhook.py
+++ b/release_webhook.py
@@ -10,7 +10,7 @@ requests.post(
         "embeds": [
             {
                 "title": f"Lightbulb v{lightbulb.__version__} released to PyPi.",
-                "description": f"Install with:\n```pip install -U hikari-lightbulb=={lightbulb.__version__}```\n[Changelog](https://hikari-lightbulb.readthedocs.io/en/latest/changelog.html#version-{lightbulb.__version__.replace('.', '-')})",
+                "description": f"Install with:\n```pip install -U hikari-lightbulb=={lightbulb.__version__}```\n[Changelog](https://hikari-lightbulb.readthedocs.io/en/latest/v1-changelog.html#version-{lightbulb.__version__.replace('.', '-')})",
             }
         ]
     },


### PR DESCRIPTION
### Summary
Rename properties that call the cache to get_x and remove decorator like Hikari did to make it more explicit when the cache is being called.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.
