### PR TITLE
Stop hiding cache calls behind properties

### DIFF
--- a/lightbulb/checks.py
+++ b/lightbulb/checks.py
@@ -119,7 +119,7 @@ async def _human_only(ctx: context.Context) -> bool:
 
 
 async def _nsfw_channel_only(ctx: context.Context) -> bool:
-    if not ctx.channel.is_nsfw:
+    if not ctx.get_channel().is_nsfw:
         raise errors.NSFWChannelOnly(f"{ctx.invoked_with} can only be used in an NSFW channel")
     return True
 
@@ -155,7 +155,8 @@ async def _has_guild_permissions(ctx: context.Context, *, permissions: hikari.Pe
 
     await _guild_only(ctx)
 
-    if ctx.guild.owner_id == ctx.author.id:
+    # Checks if the author is the server owner
+    if ctx.get_guild().owner_id == ctx.author.id:
         return True
 
     guild_roles = ctx.bot.cache.get_roles_view_for_guild(ctx.guild_id).values()
@@ -180,7 +181,7 @@ async def _bot_has_guild_permissions(ctx: context.Context, *, permissions: hikar
 
     await _guild_only(ctx)
 
-    if ctx.guild.owner_id == ctx.bot.cache.get_me().id:
+    if ctx.get_guild().owner_id == ctx.bot.cache.get_me().id:
         return True
 
     guild_roles = ctx.bot.cache.get_roles_view_for_guild(ctx.guild_id).values()
@@ -206,10 +207,10 @@ async def _has_permissions(ctx: context.Context, *, permissions: hikari.Permissi
 
     await _guild_only(ctx)
 
-    if ctx.guild.owner_id == ctx.author.id:
+    if ctx.get_guild().owner_id == ctx.author.id:
         return True
 
-    perm_over = ctx.channel.permission_overwrites.values()
+    perm_over = ctx.get_channel().permission_overwrites.values()
     perm_none = hikari.Permissions.NONE
 
     allowed_perms = functools.reduce(
@@ -231,10 +232,10 @@ async def _bot_has_permissions(ctx: context.Context, *, permissions: hikari.Perm
 
     await _guild_only(ctx)
 
-    if ctx.guild.owner_id == ctx.bot.cache.get_me().id:
+    if ctx.get_guild().owner_id == ctx.bot.cache.get_me().id:
         return True
 
-    perm_over = ctx.channel.permission_overwrites.values()
+    perm_over = ctx.get_channel().permission_overwrites.values()
     perm_none = hikari.Permissions.NONE
     bot_member = ctx.bot.cache.get_member(ctx.guild_id, ctx.bot.cache.get_me().id)
 

--- a/lightbulb/context.py
+++ b/lightbulb/context.py
@@ -176,8 +176,8 @@ class Context:
         """
 
         warnings.warn(
-            "The context property 'guild' is depreciated and will be removed in version 1.4. "
-            "Instead you should use 'get_guild'.",
+            "The context property 'guild' is deprecated and scheduled for removal in version 1.4. "
+            "You should use 'get_guild()' instead.",
             DeprecationWarning,
         )
 
@@ -206,8 +206,8 @@ class Context:
         """
 
         warnings.warn(
-            "The context property 'channel' is depreciated and will be removed in version 1.4. "
-            "Instead you should use 'get_channel'.",
+            "The context property 'channel' is deprecated and scheduled for removal in version 1.4. "
+            "You should use 'get_channel()' instead.",
             DeprecationWarning,
         )
 

--- a/lightbulb/context.py
+++ b/lightbulb/context.py
@@ -165,8 +165,7 @@ class Context:
 
         return re.sub(r"<@!?(\d+)>", replace, self.prefix)
 
-    @property
-    def guild(self) -> typing.Optional[hikari.Guild]:
+    def get_guild(self) -> typing.Optional[hikari.Guild]:
         """
         The cached :obj:`hikari.Guild` instance for the context's guild ID.
 
@@ -177,8 +176,7 @@ class Context:
             return self.bot.cache.get_available_guild(self.guild_id)
         return None
 
-    @property
-    def channel(self) -> typing.Optional[hikari.TextableChannel]:
+    def get_channel(self) -> typing.Optional[hikari.TextableChannel]:
         """
         The cached :obj:`hikari.TextableChannel` instance for the context's channel ID.
 

--- a/lightbulb/context.py
+++ b/lightbulb/context.py
@@ -23,6 +23,7 @@ import datetime
 import functools
 import re
 import typing
+import warnings
 
 import hikari
 
@@ -165,6 +166,22 @@ class Context:
 
         return re.sub(r"<@!?(\d+)>", replace, self.prefix)
 
+    @property
+    def guild(self) -> typing.Optional[hikari.Guild]:
+        """
+        The cached :obj:`hikari.Guild` instance for the context's guild ID.
+
+        This will be None if the bot is stateless, the guild is not found in the cache,
+        or the context is for a command run in DMs.
+        """
+
+        warnings.warn("The context property 'guild' is depreciated and will be removed in version 1.4. "
+                      "Instead you should use 'get_guild'.", DeprecationWarning)
+
+        if self.guild_id is not None:
+            return self.bot.cache.get_available_guild(self.guild_id)
+        return None
+
     def get_guild(self) -> typing.Optional[hikari.Guild]:
         """
         The cached :obj:`hikari.Guild` instance for the context's guild ID.
@@ -174,6 +191,22 @@ class Context:
         """
         if self.guild_id is not None:
             return self.bot.cache.get_available_guild(self.guild_id)
+        return None
+
+    @property
+    def channel(self) -> typing.Optional[hikari.TextableChannel]:
+        """
+        The cached :obj:`hikari.TextableChannel` instance for the context's channel ID.
+
+        This will be None if the bot is stateless, the channel is not found in the cache,
+        or the context is for a command run in DMs.
+        """
+
+        warnings.warn("The context property 'channel' is depreciated and will be removed in version 1.4. "
+                      "Instead you should use 'get_channel'.", DeprecationWarning)
+
+        if self.guild_id is not None:
+            return self.bot.cache.get_guild_channel(self.channel_id)
         return None
 
     def get_channel(self) -> typing.Optional[hikari.TextableChannel]:

--- a/lightbulb/context.py
+++ b/lightbulb/context.py
@@ -175,8 +175,11 @@ class Context:
         or the context is for a command run in DMs.
         """
 
-        warnings.warn("The context property 'guild' is depreciated and will be removed in version 1.4. "
-                      "Instead you should use 'get_guild'.", DeprecationWarning)
+        warnings.warn(
+            "The context property 'guild' is depreciated and will be removed in version 1.4. "
+            "Instead you should use 'get_guild'.",
+            DeprecationWarning,
+        )
 
         if self.guild_id is not None:
             return self.bot.cache.get_available_guild(self.guild_id)
@@ -202,8 +205,11 @@ class Context:
         or the context is for a command run in DMs.
         """
 
-        warnings.warn("The context property 'channel' is depreciated and will be removed in version 1.4. "
-                      "Instead you should use 'get_channel'.", DeprecationWarning)
+        warnings.warn(
+            "The context property 'channel' is depreciated and will be removed in version 1.4. "
+            "Instead you should use 'get_channel'.",
+            DeprecationWarning,
+        )
 
         if self.guild_id is not None:
             return self.bot.cache.get_guild_channel(self.channel_id)

--- a/lightbulb/slash_commands/context.py
+++ b/lightbulb/slash_commands/context.py
@@ -21,6 +21,7 @@ __all__: typing.Final[typing.List[str]] = ["SlashCommandOptionsWrapper", "SlashC
 
 import functools
 import typing
+import warnings
 
 import hikari
 
@@ -126,9 +127,27 @@ class SlashCommandContext:
         """The :obj:`hikari.Command` object for this specific context."""
         return self._command.get_command(self.guild_id)
 
+    @property
+    def channel(self) -> typing.Optional[hikari.GuildChannel]:
+        """The cached channel that the command was invoked in, or ``None`` if not found."""
+
+        warnings.warn("The slash context property 'channel' is depreciated and will be removed in version 1.4. "
+                      "Instead you should use 'get_channel'.", DeprecationWarning)
+
+        return self._interaction.get_channel()
+
     def get_channel(self) -> typing.Optional[hikari.GuildChannel]:
         """The cached channel that the command was invoked in, or ``None`` if not found."""
         return self._interaction.get_channel()
+
+    @property
+    def guild(self) -> typing.Optional[hikari.GatewayGuild]:
+        """The cached guild that the command was invoked in, or ``None`` if not found."""
+
+        warnings.warn("The slash context property 'guild' is depreciated and will be removed in version 1.4. "
+                      "Instead you should use 'get_guild'.", DeprecationWarning)
+
+        return self.bot.cache.get_guild(self.guild_id)
 
     def get_guild(self) -> typing.Optional[hikari.GatewayGuild]:
         """The cached guild that the command was invoked in, or ``None`` if not found."""

--- a/lightbulb/slash_commands/context.py
+++ b/lightbulb/slash_commands/context.py
@@ -126,13 +126,11 @@ class SlashCommandContext:
         """The :obj:`hikari.Command` object for this specific context."""
         return self._command.get_command(self.guild_id)
 
-    @property
-    def channel(self) -> typing.Optional[hikari.GuildChannel]:
+    def get_channel(self) -> typing.Optional[hikari.GuildChannel]:
         """The cached channel that the command was invoked in, or ``None`` if not found."""
         return self._interaction.get_channel()
 
-    @property
-    def guild(self) -> typing.Optional[hikari.GatewayGuild]:
+    def get_guild(self) -> typing.Optional[hikari.GatewayGuild]:
         """The cached guild that the command was invoked in, or ``None`` if not found."""
         return self.bot.cache.get_guild(self.guild_id)
 

--- a/lightbulb/slash_commands/context.py
+++ b/lightbulb/slash_commands/context.py
@@ -131,8 +131,11 @@ class SlashCommandContext:
     def channel(self) -> typing.Optional[hikari.GuildChannel]:
         """The cached channel that the command was invoked in, or ``None`` if not found."""
 
-        warnings.warn("The slash context property 'channel' is depreciated and will be removed in version 1.4. "
-                      "Instead you should use 'get_channel'.", DeprecationWarning)
+        warnings.warn(
+            "The slash context property 'channel' is depreciated and will be removed in version 1.4. "
+            "Instead you should use 'get_channel'.",
+            DeprecationWarning,
+        )
 
         return self._interaction.get_channel()
 
@@ -144,8 +147,11 @@ class SlashCommandContext:
     def guild(self) -> typing.Optional[hikari.GatewayGuild]:
         """The cached guild that the command was invoked in, or ``None`` if not found."""
 
-        warnings.warn("The slash context property 'guild' is depreciated and will be removed in version 1.4. "
-                      "Instead you should use 'get_guild'.", DeprecationWarning)
+        warnings.warn(
+            "The slash context property 'guild' is depreciated and will be removed in version 1.4. "
+            "Instead you should use 'get_guild'.",
+            DeprecationWarning,
+        )
 
         return self.bot.cache.get_guild(self.guild_id)
 

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -88,7 +88,7 @@ async def test_owner_only_fails(ctx):
 @pytest.mark.asyncio
 async def test_guild_owner_passes(ctx):
     ctx.author.id = 12345
-    ctx.guild.owner_id = 12345
+    ctx.get_guild().owner_id = 12345
     ctx.bot.intents = Intents.GUILDS
     assert await checks._has_guild_permissions(ctx, permissions=Permissions.ADMINISTRATOR)
 


### PR DESCRIPTION
### Summary
Rename properties that call the cache to get_x and remove decorator like Hikari did to make it more explicit when the cache is being called.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

