### PR TITLE
1.3.0 - checks rework **BREAKING CHANGES**

### DIFF
--- a/docs/source/slash-commands.rst
+++ b/docs/source/slash-commands.rst
@@ -164,6 +164,33 @@ Permitted types:
 
 ----
 
+Slash Command Checks
+====================
+
+You can use some of the lightbulb built-in checks with slash commands. Only the ``SlashCommand`` and ``SlashSubCommand``
+classes support checks. The checks will be run prior to the command's callback being invoked and, similar to message command
+checks, will raise a :obj:`~lightbulb.errors.CheckFailure`` exception if they do not pass. Checks are defined as
+a sequence of :obj:`~lightbulb.checks.Check` objects defined in the slash command class as seen below.
+::
+
+    import lightbulb
+    from lightbulb import slash_commands
+
+    class OwnerOnlySlashCommand(slash_commands.SlashCommand):
+        name = "foo"
+        description = "bar"
+        # Defining the list of checks
+        # You can use any built-in checks, as long as it is explicitly
+        # stated in the docstring that slash commands are supported.
+        # You can also use custom checks by wrapping the check function
+        # in a Check object
+        checks = [
+            lightbulb.owner_only,  # built-in check
+            lightbulb.Check(some_check_function),  # custom check
+        ]
+
+----
+
 API Reference
 =============
 

--- a/docs/source/v1-changelog.rst
+++ b/docs/source/v1-changelog.rst
@@ -6,6 +6,19 @@ Below are all the changelogs for the stable versions of hikari-lightbulb (versio
 
 ----
 
+Version 1.3.0
+=============
+
+**Breaking changes**
+
+- Reimplemented checks, removing all decorators apart from ``@lightbulb.check``
+
+**Other changes**
+
+- Implemented checks for slash commands
+
+- Implemented error handling for slash commands, see :obj:`~lightbulb.events.SlashCommandErrorEvent`
+
 Version 1.2.6
 =============
 

--- a/lightbulb/__init__.py
+++ b/lightbulb/__init__.py
@@ -54,4 +54,4 @@ __all__: typing.Final[typing.List[str]] = [
     *events.__all__,
 ]
 
-__version__ = "1.2.6"
+__version__ = "1.3.0"

--- a/lightbulb/checks.py
+++ b/lightbulb/checks.py
@@ -404,18 +404,16 @@ async def _has_attachment(
     return True
 
 
-def check(
-    check_func: typing.Callable[[context.Context], typing.Coroutine[typing.Any, typing.Any, bool]]
-) -> typing.Callable[[T_inv], T_inv]:
+def check(check_func: typing.Union[Check, T_predicate]) -> typing.Callable[[T_inv], T_inv]:
     """
-    A decorator which adds a custom check function to a command. The check function must be a coroutine (async def)
-    and take a single argument, which will be the command context.
+    A decorator which adds a check function to a command. The check function can be a coroutine (async def)
+    and must take a single argument, which will be the command context.
 
     This acts as a shortcut to calling :meth:`~.commands.Command.add_check` on a command instance.
 
     Args:
-        check_func (Callable[ [ :obj:`~.context.Context` ], Coroutine[ Any, Any, :obj:`bool` ] ]): The coroutine
-            to add to the command as a check.
+        check_func (Union[:obj:`~Check`, Callable[[:obj:`~.context.Context`], Union[Coroutine[Any, Any, :obj:`bool`], :obj:`bool`]]): The
+            function, coroutine or Check object to add to the command as a check.
 
     Example:
 
@@ -434,7 +432,12 @@ def check(
     """
 
     def decorate(command: T_inv) -> T_inv:
+        nonlocal check_func
         _check_check_decorator_above_commands_decorator(command)
+
+        if not isinstance(check_func, Check):
+            check_func = Check(check_func)
+
         command.add_check(check_func)
         return command
 

--- a/lightbulb/errors.py
+++ b/lightbulb/errors.py
@@ -45,6 +45,7 @@ __all__: typing.Final[typing.List[str]] = [
     "BotMissingRequiredPermission",
     "MissingRequiredAttachment",
     "CommandInvocationError",
+    "SlashCommandInvocationError",
 ]
 
 import abc
@@ -333,6 +334,23 @@ class CommandInvocationError(CommandError):
     Error raised if an error is encountered during command invocation. This will only be raised
     if all the checks passed and an error was raised somewhere inside the command.
     This effectively acts as a wrapper for the original exception for easier handling in an error handler.
+    """
+
+    def __init__(self, text: str, original: Exception) -> None:
+        self.text: str = text
+        """The error text."""
+        self.original: Exception = original
+        """The original exception that caused this to be raised."""
+
+    @property
+    def __cause__(self) -> Exception:
+        return self.original
+
+
+class SlashCommandInvocationError(CommandError):
+    """
+    Error raised if an error is encountered during slash command invocation. This will only be raised
+    if all the checks passed and an error was raised somewhere inside the command.
     """
 
     def __init__(self, text: str, original: Exception) -> None:

--- a/lightbulb/slash_commands/context.py
+++ b/lightbulb/slash_commands/context.py
@@ -98,8 +98,8 @@ class SlashCommandContext:
         return self._interaction.guild_id
 
     @property
-    def member(self) -> typing.Optional[hikari.Member]:
-        """The :obj:`hikari.Member` object for the user that invoked the slash command, or ``None`` if in DMs."""
+    def member(self) -> typing.Optional[hikari.InteractionMember]:
+        """The :obj:`hikari.InteractionMember` object for the user that invoked the slash command, or ``None`` if in DMs."""
         return self._interaction.member
 
     @property

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -49,7 +49,7 @@ async def test_guild_only_passes(ctx):
 
 @pytest.mark.asyncio
 async def test_guild_only_fails(ctx):
-    ctx.message.guild_id = None
+    ctx.guild_id = None
     with pytest.raises(errors.OnlyInGuild) as exc_info:
         await checks._guild_only(ctx)
     assert exc_info.type is errors.OnlyInGuild
@@ -57,13 +57,13 @@ async def test_guild_only_fails(ctx):
 
 @pytest.mark.asyncio
 async def test_dm_only_passes(ctx):
-    ctx.message.guild_id = None
+    ctx.guild_id = None
     assert await checks._dm_only(ctx) is True
 
 
 @pytest.mark.asyncio
 async def test_dm_only_fails(ctx):
-    ctx.message.guild_id = 123456
+    ctx.guild_id = 123456
     with pytest.raises(errors.OnlyInDM) as exc_info:
         await checks._dm_only(ctx)
     assert exc_info.type is errors.OnlyInDM
@@ -72,7 +72,7 @@ async def test_dm_only_fails(ctx):
 @pytest.mark.asyncio
 async def test_owner_only_passes(ctx):
     ctx.bot.owner_ids = [12345]
-    ctx.message.author.id = 12345
+    ctx.author.id = 12345
     assert await checks._owner_only(ctx) is True
 
 
@@ -91,21 +91,3 @@ async def test_guild_owner_passes(ctx):
     ctx.get_guild().owner_id = 12345
     ctx.bot.intents = Intents.GUILDS
     assert await checks._has_guild_permissions(ctx, permissions=Permissions.ADMINISTRATOR)
-
-
-def test_add_check_called_with_guild_only():
-    deco = checks.guild_only()
-    fake_command = deco(mock.Mock(spec_set=commands.Command))
-    fake_command.add_check.assert_called_with(checks._guild_only)
-
-
-def test_add_check_called_with_dm_only():
-    deco = checks.dm_only()
-    fake_command = deco(mock.Mock(spec_set=commands.Command))
-    fake_command.add_check.assert_called_with(checks._dm_only)
-
-
-def test_add_check_called_with_owner_only():
-    deco = checks.owner_only()
-    fake_command = deco(mock.Mock(spec_set=commands.Command))
-    fake_command.add_check.assert_called_with(checks._owner_only)


### PR DESCRIPTION
### Summary
Rework checks to use a single check decorator, with built-in checks being instances of the Check object. This version is a breaking change from 1.2.x and below - see below for the new method of defining checks:

Old
```py
@lightbulb.owner_only()
@bot.command()
async def foo(...):
    ...
```

New
```py
@lightbulb.check(lightbulb.owner_only)
@bot.command()
async def foo(...):
    ...
```

See changelog.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Closes #89 
