### PR TITLE
Replace references to BotApp with GatewayBot.

### DIFF
--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -110,7 +110,7 @@ def _return_prefix(_: typing.Any, __: typing.Any, *, prefixes: typing.Iterable[s
 
 class Bot(hikari.GatewayBot):
     """
-    A subclassed implementation of :class:`hikari.impl.bot.BotAppImpl` which contains a command handler.
+    A subclassed implementation of :class:`hikari.impl.bot.GatewayBot` which contains a command handler.
     This should be instantiated instead of the superclass if you want to be able to use
     the command handler implementation provided.
 
@@ -143,7 +143,7 @@ class Bot(hikari.GatewayBot):
         slash_commands_only (:obj:`bool`): Whether or not the bot will only be using slash commands to interact
             with discord. Defaults to ``False``. If this is ``False`` and no prefix is provided then an error will
             be raised. If ``True``, then you do not need to provide a prefix.
-        **kwargs: Other parameters passed to the :class:`hikari.impl.bot.BotAppImpl` constructor.
+        **kwargs: Other parameters passed to the :class:`hikari.impl.bot.GatewayBot` constructor.
     """
 
     def __init__(

--- a/lightbulb/plugins.py
+++ b/lightbulb/plugins.py
@@ -40,7 +40,7 @@ class EventListenerDescriptor:
     """
     Descriptor for a listener.
 
-    This provides the same introspective logic as :meth:`hikari.BotApp.listen`, but
+    This provides the same introspective logic as :meth:`hikari.GatewayBot.listen`, but
     does so using a descriptor instead of directly subscribing the function. This
     is detected when loading plugins as a way of defining event listeners within
     plugins lazily.


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->
This PR removes references to BotApp and replaces them with GatewayBot as detailed in the [latest Hikari release](https://github.com/hikari-py/hikari/releases/tag/2.0.0.dev102).

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
