### PR TITLE
Create a followup message instead if respond has been called before

### DIFF
--- a/lightbulb/slash_commands/context.py
+++ b/lightbulb/slash_commands/context.py
@@ -187,20 +187,18 @@ class SlashCommandContext:
         Returns:
             ``None``
 
-        Raises:
-            :obj:`hikari.NotFoundError`: The interaction has already had an initial response sent for it. This is
-                determined without sending a REST request so you are safe to try except this in your code.
-
         Note:
-            This can only be called **once** for each interaction. To add more information to the response
-            you should use :obj:`~lightbulb.slash_commands.SlashCommandContext.edit_response`
+            This will be a shortcut to :obj:`~lightbulb.slash_commands.SlashCommandContext.edit_response`
+            if you have called this method once.
         """
         if not self.initial_response_sent:
             resp_type = kwargs.pop("response_type", hikari.ResponseType.MESSAGE_CREATE)
             await self._interaction.create_initial_response(resp_type, content, **kwargs)
             self.initial_response_sent = True
         else:
-            raise hikari.NotFoundError("Interaction initial response has already been sent.")
+            for key in ("flags", "tts", "response_type"):
+                kwargs.pop(key, None)
+            await self.edit_response(content, **kwargs)
 
     async def edit_response(self, *args, **kwargs) -> None:
         """

--- a/lightbulb/slash_commands/context.py
+++ b/lightbulb/slash_commands/context.py
@@ -189,7 +189,7 @@ class SlashCommandContext:
 
         Note:
             This will be a shortcut to :obj:`~lightbulb.slash_commands.SlashCommandContext.edit_response`
-            if you have called this method once.
+            if you have already responded to the interaction using this method.
         """
         if not self.initial_response_sent:
             resp_type = kwargs.pop("response_type", hikari.ResponseType.MESSAGE_CREATE)


### PR DESCRIPTION
### Summary
Since lightbulb tracks whether or not it has responded to the initial response, wouldn't it be better if it creates a followup message if the respond method has been called before instead of raising an error?

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.
