### PR TITLE
Fixed a typo in docsting

### DIFF
--- a/lightbulb/plugins.py
+++ b/lightbulb/plugins.py
@@ -153,7 +153,7 @@ class Plugin:
     to allow for hot-swapping of commands.
 
     To use in your own bot you should subclass this for each plugin
-    you wish to create. Don't forget to cal ``super().__init__()`` if you
+    you wish to create. Don't forget to call ``super().__init__()`` if you
     override the ``__init__`` method.
 
     Args:


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->
Fixed a typo in a docsting in [plugins.py](https://github.com/tandemdude/hikari-lightbulb/blob/ca83c5863cb7f71292700ebbbc5e5d402ab40af6/lightbulb/plugins.py#L156) where "call" was written as "cal".

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
