### PR TITLE
1.4.0 - Slash command option defaults **BREAKING**

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ testext/
 
 # Stupid OSX files
 .DS_Store
+
+# Mypy
+mypy_report/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,6 +41,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx_rtd_theme",
+    "sphinx_rtd_dark_mode",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -63,6 +64,7 @@ intersphinx_mapping = {
 # a list of builtin themes.
 #
 html_theme = "sphinx_rtd_theme"
+default_dark_mode = True
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/slash-commands.rst
+++ b/docs/source/slash-commands.rst
@@ -42,7 +42,7 @@ Your first slash command can be written very easily:
         text: str = slash_commands.Option("Text to repeat")
 
         async def callback(self, context):
-            await context.respond(context.options["text"].value)
+            await context.respond(context.options.text)
 
 
     # Add the slash command to the bot
@@ -89,7 +89,7 @@ slash command group:
         baz: str = slash_commands.Option("Test subcommand option.")
 
         async def callback(self, context):
-            await context.respond(context.options["baz"].value)
+            await context.respond(context.options.baz)
 
 
 ----
@@ -98,7 +98,7 @@ Creating a Slash Command Subgroup
 =================================
 
 To create a slash command subgroup, you must first create a slash command group as seen in the previous
-section. The :obj`~lightbulb.slash_commands.SlashCommandGroup` class provides a ``subgroup`` decorator that
+section. The :obj:`~lightbulb.slash_commands.SlashCommandGroup` class provides a ``subgroup`` decorator that
 should be used in place of the ``subcommand`` decorator when adding a subgroup to the parent group. The subgroup
 should inherit from the :obj:`~lightbulb.slash_commands.SlashSubGroup` base class.
 
@@ -147,6 +147,7 @@ Example:
     number: typing.Optional[int] = Option("non-required integer option")
     user: hikari.User = Option("user option")
     choice: str = Option("option with choices", choices=["foo", "bar", "baz"])
+    foo: typing.Optional[str] = Option("option with default", default="foo")
 
 Permitted types:
 

--- a/docs/source/v1-changelog.rst
+++ b/docs/source/v1-changelog.rst
@@ -6,6 +6,11 @@ Below are all the changelogs for the stable versions of hikari-lightbulb (versio
 
 ----
 
+Version 1.3.2
+=============
+
+- Replace all context mention attributes with ``mentions``, returning a :obj:`hikari.Mentions` object.
+
 Version 1.3.1
 =============
 

--- a/docs/source/v1-changelog.rst
+++ b/docs/source/v1-changelog.rst
@@ -6,10 +6,28 @@ Below are all the changelogs for the stable versions of hikari-lightbulb (versio
 
 ----
 
-Version 1.3.2
+Version 1.4.0
 =============
 
+**Breaking Changes**
+
 - Replace all context mention attributes with ``mentions``, returning a :obj:`hikari.Mentions` object.
+
+- Replace :obj:`~lightbulb.slash_commands.SlashCommandContext.options` with :obj:`~lightbulb.slash_commands.SlashCommandContext.raw_options`
+
+- Replace :obj:`~lightbulb.slash_commands.SlashCommandContext.option_values` with :obj:`~lightbulb.slash_commands.SlashCommandContext.options`
+
+- Remove all deprecated functions and methods.
+
+**Other Changes**
+
+- Add ability to specify defaults for slash command options.
+
+- Add dark mode to documentation.
+
+- :obj:`~lightbulb.slash_commands.SlashCommandContext.respond` now calls :obj:`~lightbulb.slash_commands.SlashCommandContext.followup` if ``create_initial_response`` has already been called.
+
+- Fix various docstrings and typos.
 
 Version 1.3.1
 =============

--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,2 +1,3 @@
 sphinx_rtd_theme~=0.5.0
 sphinx~=3.4.2
+sphinx_rtd_dark_mode~=1.2.4

--- a/examples/in_depth_component_example.py
+++ b/examples/in_depth_component_example.py
@@ -1,0 +1,251 @@
+# -*- coding: utf-8 -*-
+# Copyright © Thomm.o 2021
+#
+# This file is part of Lightbulb.
+#
+# Lightbulb is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Lightbulb is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Lightbulb. If not, see <https://www.gnu.org/licenses/>.
+import typing
+
+import hikari
+import lightbulb
+from hikari.impl import ActionRowBuilder
+
+
+########################################################################
+# Helper functions and data.
+########################################################################
+
+# Mapping of color names to hex literal and a fact about the color.
+COLORS: typing.Mapping[str, typing.Tuple[int, str]]  = {
+    "Red": (
+        0xFF0000,
+        "Due to it's long wavelength, red is the first color a baby sees!",
+    ),
+    "Green": (
+        0x00FF00,
+        "Plants green color help them use photosynthesis!",
+    ),
+    "Blue": (
+        0x0000FF,
+        "Globally, blue is the most common favorite color!",
+    ),
+    "Orange": (
+        0xFFA500,
+        "The color orange is named after its fruity counterpart, the orange!"
+    ),
+    "Purple": (
+        0xA020F0,
+        "Purple is the hardest color for human eyes to distinguish!",
+    ),
+    "Yellow": (
+        0xFFFF00,
+        "Taxi's and school buses are yellow because it's so easy to see!",
+    ),
+    "Black": (
+        0x000000,
+        "Black is a color which results from the absence of visible light!"
+    ),
+    "White": (
+        0xFFFFFF,
+        "White objects fully reflect and scatter all visible light!"
+    ),
+}
+
+
+async def generate_rows(bot: lightbulb.Bot) -> typing.Iterable[ActionRowBuilder]:
+    """Generate 2 action rows with 4 buttons each."""
+
+    # This will hold our action rows of buttons. The limit
+    # imposed by Discord is 5 rows with 5 buttons each. We
+    # will not use that many here, however.
+    rows: typing.Iterable[ActionRowBuilder] = []
+
+    # Here we iterate len(COLORS) times.
+    for i in range(len(COLORS)):
+        if i == 0:
+            # If i is 0, we need to build our first action row.
+            row: ActionRowBuilder = bot.rest.build_action_row()
+
+        elif i % 4 == 0 and i != 0:
+            # If i is evenly divided by 4, and not 0 we want to
+            # append the first row to rows and build the second
+            # action row. (Gives a more even button layout)
+            rows.append(row)
+            row = bot.rest.build_action_row()
+
+        # Extract the current color from the mapping and assign
+        # to this label var for later.
+        label = [*COLORS.keys()][i]
+
+        # We use an enclosing scope here so that we can easily chain
+        # method calls of the action row.
+        (
+            # Adding the buttons into the action row.
+            row.add_button(
+                # Gray button style, see also PRIMARY, and DANGER.
+                hikari.ButtonStyle.SECONDARY,
+                # Set the buttons custom ID to the label.
+                label,
+            )
+            # Set the actual label.
+            .set_label(label)
+            # Finally add the button to the container.
+            .add_to_container()
+        )
+
+    # Append the second action row to rows after the for loop.
+    rows.append(row)
+
+    # Return the action rows from the function.
+    return rows
+
+
+async def handle_responses(
+    bot: lightbulb.Bot,
+    author: hikari.User,
+    message: hikari.Message,
+) -> None:
+    """Watches for events, and handles responding to them."""
+
+    # Now we need to check if the user who ran the command interacts
+    # with our buttons, we stop watching after 120 seconds (2 mins) of
+    # inactivity.
+    async with bot.stream(hikari.InteractionCreateEvent, 120).filter(
+        # Here we filter out events we don't care about.
+        lambda e: (
+            # A component interaction is a button interaction.
+            isinstance(e.interaction, hikari.ComponentInteraction)
+            # Make sure the command author hit the button.
+            and e.interaction.user == author
+            # Make sure the button was attached to our message.
+            and e.interaction.message == message
+        )
+    ) as stream:
+        async for event in stream:
+            # If we made it through the filter, the user has clicked
+            # one of our buttons, so we grab the custom ID.
+            cid = event.interaction.custom_id
+
+            # Create new embed with info on the color they selected
+            embed = hikari.Embed(
+                # The color name.
+                title=cid,
+                # The hex literal we stored earlier.
+                color=COLORS[cid][0],
+                # The fact about the color.
+                description=COLORS[cid][1],
+            )
+
+            # If we haven't responded to the interaction yet, we
+            # need to create the initial response. Otherwise, we
+            # need to edit the initial response.
+            try:
+                # NOTE: We don't have to add the buttons again as they
+                # are already on the message. So we don't have to
+                # pass components here. If we wanted to update the
+                # buttons we would pass a new list of action rows.
+                await event.interaction.create_initial_response(
+                    # The response type is required when creating
+                    # the inital response. We use MESSAGE_UPDATE
+                    # because we are updating a message we previously
+                    # sent. NOTE: even though the message was already
+                    # sent, this is still the **INITIAL RESPONSE** to
+                    # the interaction event (button click).
+                    hikari.ResponseType.MESSAGE_UPDATE,
+                    embed=embed,
+                )
+            except hikari.NotFoundError:
+                # This error is raised if we have already sent the
+                # initial response. Notice no response type is needed
+                # here, so we just edit the initial response with the
+                # new embed.
+                await event.interaction.edit_initial_response(
+                    embed=embed,
+                )
+
+    # Once were back outside the stream loop, it's been 2 minutes since
+    # the last interaction and it's time now to remove the buttons from
+    # the message to prevent further interaction.
+    await message.edit(
+        # Set components to an empty list to get rid of them.
+        components=[]
+    )
+
+
+########################################################################
+# Create the bot.
+########################################################################
+
+
+# Instantiate the bot.
+bot = lightbulb.Bot(token="YOUR_TOKEN", prefix="!")
+
+
+# Create the message command.
+@bot.command(name="rgb")
+async def rgb_command(ctx: lightbulb.Context) -> None:
+    """Get facts on different colors!"""
+
+    # Generate the action rows.
+    rows: typing.Iterable[ActionRowBuilder] = await generate_rows(ctx.bot)
+
+    # Send the initial response with our action rows, and save the
+    # message for handling interaction responses.
+    message = await ctx.respond(
+        hikari.Embed(title="Pick a color"),
+        components=rows,
+        reply=True,
+    )
+
+    # Handle interaction responses to the initial message.
+    await handle_responses(ctx.bot, ctx.author, message)
+
+
+# Create the slash command.
+class Rgb(lightbulb.slash_commands.SlashCommand):
+    # The command description.
+    description: str = "Get facts on different colors!"
+    # Pass a sequence of guild id's here for testing, but remove them to
+    # make the command global. Takes 1 hr to propagate global commands.
+    # This is a discord limitation.
+    enabled_guilds: typing.Iterable[int] = [1234]
+
+    async def callback(self, ctx: lightbulb.slash_commands.SlashCommandContext) -> None:
+        # Generate the action rows.
+        rows: typing.Iterable[ActionRowBuilder] = await generate_rows(ctx.bot)
+
+        # Send the initial response with our action rows. This does
+        # not return a message however. This is due to using a slash
+        # command context, and not a regular message context.
+        await ctx.respond(
+            hikari.Embed(title="Pick a color"),
+            components=rows,
+        )
+
+        # Handle interaction responses to the initial message.
+        await handle_responses(
+            ctx.bot,
+            ctx.author,
+            # Because we dont have the initial response message yet,
+            # we fetch it here in order to pass it to the function.
+            await ctx.interaction.fetch_initial_response()
+        )
+
+
+# Add the slash command to the bot.
+bot.add_slash_command(Rgb)
+
+
+# Run the bot.
+bot.run()

--- a/lightbulb/__init__.py
+++ b/lightbulb/__init__.py
@@ -56,4 +56,4 @@ __all__: typing.Final[typing.List[str]] = [
     *slash_commands.__all__,
 ]
 
-__version__ = "1.3.1"
+__version__ = "1.4.0"

--- a/lightbulb/checks.py
+++ b/lightbulb/checks.py
@@ -63,10 +63,10 @@ if typing.TYPE_CHECKING:
 T_inv = typing.TypeVar("T_inv", bound=commands.Command)
 T_predicate = typing.Callable[
     [typing.Union[context.Context, slash_commands.SlashCommandContext]],
-    typing.Union[typing.Coroutine[typing.Any, typing.Any, bool], bool],
+    typing.Union[typing.Coroutine[None, None, bool], bool],
 ]
 T_slash_predicate = typing.Callable[
-    [slash_commands.SlashCommandContext], typing.Union[typing.Coroutine[typing.Any, typing.Any, bool], bool]
+    [slash_commands.SlashCommandContext], typing.Union[typing.Coroutine[None, None, bool], bool]
 ]
 T_contexts = typing.Union[context.Context, slash_commands.SlashCommandContext]
 
@@ -184,8 +184,8 @@ async def _nsfw_channel_only(ctx: T_contexts) -> bool:
     return True
 
 
-def _role_check(member_roles: typing.Sequence[hikari.Snowflake], *, roles: typing.Sequence[int], func) -> bool:
-    return func(r in member_roles for r in roles)
+def _role_check(member_roles: typing.Sequence[hikari.Snowflake], *, roles: typing.Sequence[int], func_) -> bool:
+    return func_(r in member_roles for r in roles)
 
 
 async def _has_roles(ctx: T_contexts, *, role_check):
@@ -513,7 +513,7 @@ def has_roles(
     role1: snowflakes.SnowflakeishOr[hikari.PartialRole],
     *role_ids: snowflakes.SnowflakeishOr[hikari.PartialRole],
     mode: typing.Literal["all", "any"] = "all",
-):
+) -> Check:
     """
     Prevents a command from being used by anyone missing roles according to the given mode.
     This check supports slash commands.
@@ -548,13 +548,13 @@ def has_roles(
         functools.partial(
             _has_roles,
             role_check=functools.partial(
-                _role_check, roles=[int(role1), *[int(r) for r in role_ids]], func={"all": all, "any": any}[mode]
+                _role_check, roles=[int(role1), *[int(r) for r in role_ids]], func_={"all": all, "any": any}[mode]
             ),
         )
     )
 
 
-def has_guild_permissions(perm1: hikari.Permissions, *permissions: hikari.Permissions):
+def has_guild_permissions(perm1: hikari.Permissions, *permissions: hikari.Permissions) -> Check:
     """
     Prevents the command from being used by a member missing any of the required
     guild permissions (this takes into account both role permissions and channel overwrites,
@@ -586,7 +586,7 @@ def has_guild_permissions(perm1: hikari.Permissions, *permissions: hikari.Permis
     )
 
 
-def bot_has_guild_permissions(perm1: hikari.Permissions, *permissions: hikari.Permissions):
+def bot_has_guild_permissions(perm1: hikari.Permissions, *permissions: hikari.Permissions) -> Check:
     """
     Prevents the command from being used if the bot is missing any of the required
     guild permissions (this takes into account both role permissions and channel overwrites).
@@ -616,7 +616,7 @@ def bot_has_guild_permissions(perm1: hikari.Permissions, *permissions: hikari.Pe
     )
 
 
-def has_role_permissions(perm1: hikari.Permissions, *permissions: hikari.Permissions):
+def has_role_permissions(perm1: hikari.Permissions, *permissions: hikari.Permissions) -> Check:
     """
     Prevents the command from being used by a member missing any of the required
     role permissions.
@@ -646,7 +646,7 @@ def has_role_permissions(perm1: hikari.Permissions, *permissions: hikari.Permiss
     )
 
 
-def bot_has_role_permissions(perm1: hikari.Permissions, *permissions: hikari.Permissions):
+def bot_has_role_permissions(perm1: hikari.Permissions, *permissions: hikari.Permissions) -> Check:
     """
     Prevents the command from being used if the bot is missing any of the required
     role permissions.
@@ -676,7 +676,7 @@ def bot_has_role_permissions(perm1: hikari.Permissions, *permissions: hikari.Per
     )
 
 
-def has_channel_permissions(perm1: hikari.Permissions, *permissions: hikari.Permissions):
+def has_channel_permissions(perm1: hikari.Permissions, *permissions: hikari.Permissions) -> Check:
     """
     Prevents the command from being used by a member missing any of the required
     channel permissions (permissions granted by a permission overwrite).
@@ -706,7 +706,7 @@ def has_channel_permissions(perm1: hikari.Permissions, *permissions: hikari.Perm
     )
 
 
-def bot_has_channel_permissions(perm1: hikari.Permissions, *permissions: hikari.Permissions):
+def bot_has_channel_permissions(perm1: hikari.Permissions, *permissions: hikari.Permissions) -> Check:
     """
     Prevents the command from being used if the bot is missing any of the required
     channel permissions (permissions granted by a permission overwrite).
@@ -736,7 +736,7 @@ def bot_has_channel_permissions(perm1: hikari.Permissions, *permissions: hikari.
     )
 
 
-def has_permissions(perm1: hikari.Permissions, *permissions: hikari.Permissions):
+def has_permissions(perm1: hikari.Permissions, *permissions: hikari.Permissions) -> Check:
     """
     Alias for :obj:`~has_channel_permissions` for backwards compatibility.
 
@@ -750,7 +750,7 @@ def has_permissions(perm1: hikari.Permissions, *permissions: hikari.Permissions)
     return has_channel_permissions(perm1, *permissions)
 
 
-def bot_has_permissions(perm1: hikari.Permissions, *permissions: hikari.Permissions):
+def bot_has_permissions(perm1: hikari.Permissions, *permissions: hikari.Permissions) -> Check:
     """
     Alias for :obj:`~bot_has_channel_permissions` for backwards compatibility.
 
@@ -764,7 +764,7 @@ def bot_has_permissions(perm1: hikari.Permissions, *permissions: hikari.Permissi
     return bot_has_channel_permissions(perm1, *permissions)
 
 
-def has_attachment(*extensions: str):
+def has_attachment(*extensions: str) -> Check:
     """
     Prevents the command from being used if the invocation message
     does not include any attachments.

--- a/lightbulb/checks.py
+++ b/lightbulb/checks.py
@@ -36,8 +36,6 @@ __all__: typing.Final[typing.List[str]] = [
     "bot_has_role_permissions",
     "has_channel_permissions",
     "bot_has_channel_permissions",
-    "has_permissions",
-    "bot_has_permissions",
     "has_attachment",
     "check",
     "check_exempt",
@@ -734,34 +732,6 @@ def bot_has_channel_permissions(perm1: hikari.Permissions, *permissions: hikari.
         ),
         add_to_command_hook=lambda cmd: setattr(cmd, "bot_required_permissions", total_perms),
     )
-
-
-def has_permissions(perm1: hikari.Permissions, *permissions: hikari.Permissions) -> Check:
-    """
-    Alias for :obj:`~has_channel_permissions` for backwards compatibility.
-
-    This is deprecated, use :obj:`~has_channel_permissions` instead.
-    """
-    warnings.warn(
-        "The permissions check 'has_permissions' is deprecated and scheduled for removal in version 1.4. "
-        "You should use 'has_channel_permissions' instead.",
-        DeprecationWarning,
-    )
-    return has_channel_permissions(perm1, *permissions)
-
-
-def bot_has_permissions(perm1: hikari.Permissions, *permissions: hikari.Permissions) -> Check:
-    """
-    Alias for :obj:`~bot_has_channel_permissions` for backwards compatibility.
-
-    This is deprecated, use :obj:`~bot_has_channel_permissions` instead.
-    """
-    warnings.warn(
-        "The permissions check 'bot_has_permissions' is deprecated and scheduled for removal in version 1.4. "
-        "You should use 'bot_has_channel_permissions' instead.",
-        DeprecationWarning,
-    )
-    return bot_has_channel_permissions(perm1, *permissions)
 
 
 def has_attachment(*extensions: str) -> Check:

--- a/lightbulb/command_handler.py
+++ b/lightbulb/command_handler.py
@@ -103,7 +103,7 @@ def when_mentioned_or(
             bot = lightbulb.Bot(prefix=lightbulb.when_mentioned_or(get_prefix), ...)
     """
 
-    async def get_prefixes(bot, message):
+    async def get_prefixes(bot: Bot, message: hikari.Message) -> typing.Sequence[str]:
         mentions = [f"<@{bot.get_me().id}> ", f"<@!{bot.get_me().id}> "]
 
         if callable(prefix_provider):
@@ -120,6 +120,7 @@ def when_mentioned_or(
         elif prefixes is None:
             return mentions
         else:
+            prefixes = typing.cast(collections.AsyncIterable, prefixes)
             return mentions + [prefix async for prefix in prefixes]
 
     return get_prefixes
@@ -127,7 +128,7 @@ def when_mentioned_or(
 
 # Prefixes may be a string or iterable of strings. A string is a sequence of strings too by definition,
 # so this type hint _is_ correct.
-def _return_prefix(_: typing.Any, __: typing.Any, *, prefixes: typing.Iterable[str]) -> typing.Sequence[str]:
+def _return_prefix(_: Bot, __: hikari.Message, *, prefixes: typing.Iterable[str]) -> typing.Iterable[str]:
     return prefixes
 
 
@@ -181,7 +182,7 @@ class Bot(hikari.GatewayBot):
         delete_unbound_slash_commands: bool = True,
         recreate_changed_slash_commands: bool = True,
         slash_commands_only: bool = False,
-        **kwargs,
+        **kwargs: hikari.UndefinedType,
     ) -> None:
         super().__init__(token, **kwargs)
 
@@ -1238,7 +1239,7 @@ class Bot(hikari.GatewayBot):
         def compare_commands(
             lb_cmd: typing.Union[slash_commands.SlashCommand, slash_commands.SlashCommandGroup],
             hk_cmd: hikari.Command,
-            _guild_ids: typing.Optional[typing.List] = None,
+            _guild_ids: typing.Optional[typing.List[hikari.Snowflakeish]] = None,
         ) -> bool:
             # If one command is global and the other isn't
             if (not lb_cmd.enabled_guilds and _guild_ids) or (lb_cmd.enabled_guilds and not _guild_ids):

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -48,6 +48,7 @@ from lightbulb.converters import _UnionConverter
 if typing.TYPE_CHECKING:
     from lightbulb import checks as checks_
     from lightbulb import plugins
+    from lightbulb.checks import T_predicate
 
 _LOGGER = logging.getLogger("lightbulb")
 
@@ -227,7 +228,7 @@ class Command:
 
     def __init__(
         self,
-        callback: typing.Callable,
+        callback: typing.Callable[[context_.Context], typing.Coroutine[None, None, None]],
         name: str,
         allow_extra_arguments: bool,
         aliases: typing.Iterable[str],
@@ -240,7 +241,7 @@ class Command:
         self._aliases = aliases
         self.hidden = hidden
         self._checks: typing.List[checks_.Check] = []
-        self._check_exempt_predicate = lambda ctx: False
+        self._check_exempt_predicate: T_predicate = lambda ctx: False
         self._raw_error_listener = None
         self._raw_before_invoke = None
         self._raw_after_invoke = None

--- a/lightbulb/commands.py
+++ b/lightbulb/commands.py
@@ -402,7 +402,7 @@ class Command:
 
             .. code-block:: python
 
-                @lightbulb.owner_only()
+                @lightbulb.check(lightbulb.owner_only)
                 @bot.command()
                 async def foo(ctx):
                     await ctx.respond("bar")

--- a/lightbulb/context.py
+++ b/lightbulb/context.py
@@ -126,22 +126,10 @@ class Context:
         """Optional timestamp of the previous edit of the context message."""
         return self._message.edited_timestamp
 
-    # XXX: these are at the time of writing typing.Sequence objects, but will
-    # be refactored to use typing.AbstractSet as part of https://github.com/nekokatt/hikari/issues/273.
     @property
-    def user_mentions(self) -> typing.Collection[hikari.Snowflake]:
-        """The users mentioned in the context message."""
-        return self._message.user_mentions
-
-    @property
-    def role_mentions(self) -> typing.Collection[hikari.Snowflake]:
-        """The roles mentioned in the context message."""
-        return self._message.role_mentions
-
-    @property
-    def channel_mentions(self) -> typing.Collection[hikari.Snowflake]:
-        """The channels mentioned in the context message."""
-        return self._message.channel_mentions
+    def mentions(self) -> hikari.Mentions:
+        """The mentions that exist in the message that triggered the command."""
+        return self._message.mentions
 
     @property
     def attachments(self) -> typing.Sequence[hikari.Attachment]:
@@ -160,7 +148,7 @@ class Context:
         returns the raw prefix.
         """
 
-        def replace(match):
+        def replace(match: re.Match) -> str:
             user = self.bot.cache.get_user(hikari.Snowflake(match.group(1)))
             return f"@{user}" if user is not None else self.prefix
 

--- a/lightbulb/context.py
+++ b/lightbulb/context.py
@@ -154,25 +154,6 @@ class Context:
 
         return re.sub(r"<@!?(\d+)>", replace, self.prefix)
 
-    @property
-    def guild(self) -> typing.Optional[hikari.Guild]:
-        """
-        The cached :obj:`hikari.Guild` instance for the context's guild ID.
-
-        This will be None if the bot is stateless, the guild is not found in the cache,
-        or the context is for a command run in DMs.
-        """
-
-        warnings.warn(
-            "The context property 'guild' is deprecated and scheduled for removal in version 1.4. "
-            "You should use 'get_guild()' instead.",
-            DeprecationWarning,
-        )
-
-        if self.guild_id is not None:
-            return self.bot.cache.get_available_guild(self.guild_id)
-        return None
-
     def get_guild(self) -> typing.Optional[hikari.Guild]:
         """
         The cached :obj:`hikari.Guild` instance for the context's guild ID.
@@ -182,25 +163,6 @@ class Context:
         """
         if self.guild_id is not None:
             return self.bot.cache.get_available_guild(self.guild_id)
-        return None
-
-    @property
-    def channel(self) -> typing.Optional[hikari.TextableChannel]:
-        """
-        The cached :obj:`hikari.TextableChannel` instance for the context's channel ID.
-
-        This will be None if the bot is stateless, the channel is not found in the cache,
-        or the context is for a command run in DMs.
-        """
-
-        warnings.warn(
-            "The context property 'channel' is deprecated and scheduled for removal in version 1.4. "
-            "You should use 'get_channel()' instead.",
-            DeprecationWarning,
-        )
-
-        if self.guild_id is not None:
-            return self.bot.cache.get_guild_channel(self.channel_id)
         return None
 
     def get_channel(self) -> typing.Optional[hikari.TextableChannel]:

--- a/lightbulb/converters.py
+++ b/lightbulb/converters.py
@@ -264,16 +264,6 @@ async def guild_voice_channel_converter(arg: WrappedArg) -> hikari.GuildVoiceCha
     return channel
 
 
-# Deprecated, as this may change in the future to not just be a GuildVoiceChannel should Discord add new features,
-# so this shouldn't be used as it may cause breaking changes later.
-def voice_channel_converter(arg: WrappedArg) -> typing.Coroutine[typing.Any, typing.Any, hikari.GuildVoiceChannel]:
-    warnings.warn(
-        "voice_channel_converter is deprecated, use guild_voice_channel_converter instead",
-        category=DeprecationWarning,
-    )
-    return guild_voice_channel_converter(arg)
-
-
 async def category_converter(arg: WrappedArg) -> hikari.GuildCategory:
     """
     Converter to transform a command argument into a :obj:`~hikari.GuildCategory` object.

--- a/lightbulb/plugins.py
+++ b/lightbulb/plugins.py
@@ -153,7 +153,7 @@ class Plugin:
     to allow for hot-swapping of commands.
 
     To use in your own bot you should subclass this for each plugin
-    you wish to create. Don't forget to cal ``super().__init__()`` if you
+    you wish to create. Don't forget to call ``super().__init__()`` if you
     override the ``__init__`` method.
 
     Args:

--- a/lightbulb/slash_commands/context.py
+++ b/lightbulb/slash_commands/context.py
@@ -187,20 +187,18 @@ class SlashCommandContext:
         Returns:
             ``None``
 
-        Raises:
-            :obj:`hikari.NotFoundError`: The interaction has already had an initial response sent for it. This is
-                determined without sending a REST request so you are safe to try except this in your code.
-
         Note:
-            This can only be called **once** for each interaction. To add more information to the response
-            you should use :obj:`~lightbulb.slash_commands.SlashCommandContext.edit_response`
+            This will be a shortcut to :obj:`~lightbulb.slash_commands.SlashCommandContext.edit_response`
+            if you have called this method once.
         """
         if not self.initial_response_sent:
             resp_type = kwargs.pop("response_type", hikari.ResponseType.MESSAGE_CREATE)
             await self._interaction.create_initial_response(resp_type, content, **kwargs)
             self.initial_response_sent = True
         else:
-            raise hikari.NotFoundError("Interaction initial response has already been sent.")
+            for key in ("flags", "tts", "response_type"):
+                kwargs.pop(key, None)
+            await self.edit_response(content, **kwargs)
 
     async def edit_response(self, *args, **kwargs) -> None:
         """

--- a/lightbulb/slash_commands/context.py
+++ b/lightbulb/slash_commands/context.py
@@ -189,7 +189,7 @@ class SlashCommandContext:
 
         Note:
             This will be a shortcut to :obj:`~lightbulb.slash_commands.SlashCommandContext.edit_response`
-            if you have called this method once.
+            if you have already responded to the interaction using this method.
         """
         if not self.initial_response_sent:
             resp_type = kwargs.pop("response_type", hikari.ResponseType.MESSAGE_CREATE)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,29 @@
+[mypy]
+# general settings
+strict = true
+check_untyped_defs = true
+incremental = true
+namespace_packages = true
+no_implicit_optional = true
+pretty = true
+python_version = 3.8
+show_column_numbers = true
+show_error_codes = true
+show_error_context = true
+
+# stuff to allow
+allow_untyped_globals = false
+allow_redefinition = true
+
+# stuff to disallow
+disallow_untyped_decorators = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+
+# warnings
+warn_no_return = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unreachable = true
+warn_unused_configs = true
+warn_unused_ignores = true

--- a/noxfile.py
+++ b/noxfile.py
@@ -55,6 +55,6 @@ def format(session):
 
 @nox.session(reuse_venv=True)
 def sphinx(session):
-    session.install("-U", "sphinx", "sphinx_rtd_theme")
+    session.install("-U", "sphinx", "sphinx_rtd_theme", "sphinx_rtd_dark_mode")
     session.install("-Ur", "requirements.txt")
     session.run("python", "-m", "sphinx.cmd.build", "docs/source", "docs/build", "-b", "html")


### PR DESCRIPTION
### Summary
**This pull request is breaking for versions 1.3.x**

Notes on breaking changes:
- ``SlashCommandContext.options`` has been renamed to ``SlashCommandContext.raw_options``.
- ``SlashCommandContext.option_values`` has been renamed to ``SlashCommandContext.options``.
- All deprecated methods have been removed.
- ``Context.user_mentions``, ``Context.channel_mentions``, ``Context.role_mentions`` have all been removed and replaced with ``Context.mentions``.

See changelog for more details.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
