### PR TITLE
Changed option_values to options

### DIFF
--- a/examples/basic_slash_command_bot_example.py
+++ b/examples/basic_slash_command_bot_example.py
@@ -50,7 +50,7 @@ class Echo(lightbulb.slash_commands.SlashCommand):
 
     async def callback(self, context):
         # Respond with the value of the 'text' option - the text that the user input.
-        await context.respond(context.option_values.text)
+        await context.respond(context.options.text)
 
 
 bot.add_slash_command(Ping)

--- a/lightbulb/slash_commands/commands.py
+++ b/lightbulb/slash_commands/commands.py
@@ -124,7 +124,7 @@ class Option:
                 text: str = Option("Text to repeat")
 
                 async def callback(self, context):
-                    await context.respond(context.option_values.text)
+                    await context.respond(context.options.text)
 
     """
 

--- a/lightbulb/slash_commands/context.py
+++ b/lightbulb/slash_commands/context.py
@@ -37,7 +37,7 @@ class SlashCommandOptionsWrapper:
     :obj:`~lightbulb.slash_commands.SlashCommandOptionsWrapper.option_name` will return either the option's value,
     or ``None`` if the option was not provided in the slash command invocation.
 
-    This is accessible through :obj:`~lightbulb.slash_commands.SlashCommandContext.option_values`
+    This is accessible through :obj:`~lightbulb.slash_commands.SlashCommandContext.options`
 
     Args:
         options (Mapping[:obj:`str`, :obj:`hikari.CommandInteractionOption`): The options that the slash command


### PR DESCRIPTION
### Summary
Changed all instances of `option_values` to `options` since v1.4.0 breaking changes

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
