### PR TITLE
Add CONSUME_REST modifier to example echo command

### DIFF
--- a/examples/plugin_example.py
+++ b/examples/plugin_example.py
@@ -25,7 +25,7 @@ plugin = lightbulb.Plugin("Example Plugin")
 
 
 @plugin.command()
-@lightbulb.option("text", "Text to repeat")
+@lightbulb.option("text", "Text to repeat", modifier=commands.OptionModifier.CONSUME_REST)
 @lightbulb.command("echo", "Repeats the user's input")
 @lightbulb.implements(commands.PrefixCommand)
 async def echo(ctx):


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->
Add the `lightbulb.commands.OptionModifier.CONSUME_REST` to the `echo` command in the plugin example so it repeats everything instead of just one word

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
