### PR TITLE
Fix issue with prevented 'load_extensions_from' working on Windows

### DIFF
--- a/lightbulb/app.py
+++ b/lightbulb/app.py
@@ -24,6 +24,7 @@ import functools
 import importlib
 import inspect
 import logging
+import os
 import pathlib
 import re
 import sys
@@ -532,7 +533,7 @@ class BotApp(hikari.GatewayBot):
 
         cwd_len = len(f"{pathlib.Path.cwd()}/")
         for ext in path.glob(("**/" if recursive else "") + "[!_]*.py"):
-            self.load_extensions(f"{ext}"[cwd_len:-3].replace("/", "."))
+            self.load_extensions(f"{ext}"[cwd_len:-3].replace(os.sep, "."))
 
     async def fetch_owner_ids(self) -> t.Sequence[hikari.SnowflakeishOr[int]]:
         """


### PR DESCRIPTION
### Summary
Fixes [this issue](https://ptb.discord.com/channels/626608699942764544/663808949275066369/914970308136534106).

### Checklist
- [x] I have run `nox` and all the pipelines have passed.

### Related issues
None.
