### PR TITLE
Added LightbulbStartedEvent

### DIFF
--- a/lightbulb/app.py
+++ b/lightbulb/app.py
@@ -344,7 +344,6 @@ class BotApp(hikari.GatewayBot):
 
         try:
             await internal.manage_application_commands(self)
-            await self.dispatch(events.LightbulbStartedEvent(app=self))
         except hikari.ForbiddenError as exc:
             error_msg = str(exc)
             match = _APPLICATION_CMD_ERROR_REGEX.search(error_msg)
@@ -352,6 +351,8 @@ class BotApp(hikari.GatewayBot):
             raise errors.ApplicationCommandCreationFailed(
                 f"Application command creation failed for guild {guild_id!r}. Is your bot in the guild and was it invited with the 'application.commands' scope?"
             ) from exc
+        finally:
+            await self.dispatch(events.LightbulbStartedEvent(app=self))
 
     @staticmethod
     def _get_events_for_application_command(

--- a/lightbulb/app.py
+++ b/lightbulb/app.py
@@ -344,6 +344,7 @@ class BotApp(hikari.GatewayBot):
 
         try:
             await internal.manage_application_commands(self)
+            await self.dispatch(events.LightbulbStartedEvent(app=self))
         except hikari.ForbiddenError as exc:
             error_msg = str(exc)
             match = _APPLICATION_CMD_ERROR_REGEX.search(error_msg)

--- a/lightbulb/events.py
+++ b/lightbulb/events.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 __all__ = [
     "LightbulbEvent",
+    "LightbulbStartedEvent",
     "CommandErrorEvent",
     "PrefixCommandErrorEvent",
     "PrefixCommandInvocationEvent",
@@ -63,6 +64,11 @@ class LightbulbEvent(hikari.Event, abc.ABC):
     def bot(self) -> app_.BotApp:
         """BotApp instance for this event. Alias for :obj:`~LightbulbEvent.app`."""
         return self.app
+
+
+@attr.s(slots=True, weakref_slot=False)
+class LightbulbStartedEvent(LightbulbEvent):
+    """Event dispatched after the application commands have been managed."""
 
 
 @attr.s(slots=True, weakref_slot=False)


### PR DESCRIPTION
### Summary
Added LightbulbStartedEvent, dispatched after application command creation.

### Checklist
- [x ] I have run `nox` and all the pipelines have passed.

### Related issues
Hikari provide the `StartedEvent`, but it is dispatched before lightbulb application command creation is done, so application command `instances` may be empty
