### PR TITLE
2.1.0

### DIFF
--- a/docs/source/changelogs/v2-changelog.rst
+++ b/docs/source/changelogs/v2-changelog.rst
@@ -6,6 +6,18 @@ Below are all the changelogs for the stable versions of hikari-lightbulb (versio
 
 ----
 
+Version 2.1.0
+=============
+
+- Add :obj:`lightbulb.events.LightbulbStartedEvent`.
+
+- Add ``cls`` kwarg to :obj:`lightbulb.decorators.command` and :obj:`lightbulb.decorators.option` to allow you to use your
+  own ``CommandLike`` and ``OptionLike`` classes.
+
+- Add :obj:`lightbulb.context.Context.invoked`.
+
+- Implement ability to use namespace packages to extend lightbulb. See :ref:`extension-libs`.
+
 Version 2.0.4
 =============
 

--- a/docs/source/extension-libs.rst
+++ b/docs/source/extension-libs.rst
@@ -12,13 +12,13 @@ on discord.
 
 ----
 
-lightbulb-filament
-==================
+lightbulb-ext-filament
+======================
 
 An extension library written by thomm.o which provides various utility methods, extensions, templating, and an alternate
 method of declaring commands.
 
-- Repository: `GitHub <https://github.com/tandemdude/filament>`_
+- Repository: `GitHub <https://github.com/tandemdude/lightbulb-ext-filament>`_
 
 - Documentation: `Readthedocs <https://filament.readthedocs.io/en/latest/>`_
 
@@ -30,7 +30,7 @@ Declaring commands:
 .. code-block:: python
 
     import lightbulb
-    import filament
+    from lightbulb.ext import filament
 
     class EchoCommand(filament.CommandLike):
         implements = [lightbulb.SlashCommand, lightbulb.PrefixCommand]
@@ -92,8 +92,8 @@ Component menu:
 
 ----
 
-lightbulb-wtf
-=============
+lightbulb-ext-wtf
+=================
 
 A library written by thomm.o which provides a completely different method of declaring commands. This library started
 out as a joke to see how badly python's syntax could be abused but turned in to a fully functional method of declaring
@@ -111,8 +111,8 @@ Declaring commands:
 .. code-block:: python
 
     import lightbulb
-    from wtf import Command, Options, Option
-    from wtf import Implements, Name, Description, Executes
+    from lightbulb.ext.wtf import Command, Options, Option
+    from lightbulb.ext.wtf import Implements, Name, Description, Executes
 
     echo = Command[
         Implements[lightbulb.SlashCommand, lightbulb.PrefixCommand],

--- a/docs/source/extension-libs.rst
+++ b/docs/source/extension-libs.rst
@@ -1,0 +1,132 @@
+.. _extension-libs:
+
+===================
+Extension Libraries
+===================
+
+This is a collection of libraries that have been written for hikari-lightbulb to aid in the development of your
+bots and/or to make your life generally easier during your time with the library.
+
+If you have written an extension library that you would like to have added to this list, please contact thomm.o#8637
+on discord.
+
+----
+
+lightbulb-filament
+==================
+
+An extension library written by thomm.o which provides various utility methods, extensions, templating, and an alternate
+method of declaring commands.
+
+- Repository: `GitHub <https://github.com/tandemdude/filament>`_
+
+- Documentation: `Readthedocs <https://filament.readthedocs.io/en/latest/>`_
+
+Quick Examples
+--------------
+
+Declaring commands:
+
+.. code-block:: python
+
+    import lightbulb
+    import filament
+
+    class EchoCommand(filament.CommandLike):
+        implements = [lightbulb.SlashCommand, lightbulb.PrefixCommand]
+
+        name = "echo"
+        description = "repeats the given text"
+
+        text_option = filament.opt("text", "text to repeat")
+
+        async def callback(self, ctx):
+            await ctx.respond(ctx.options.text)
+
+For more on what the library provides, you should visit its documentation.
+
+----
+
+lightbulb-neon
+==============
+
+An extension library written by NeonJonn which makes it easier to handle and process component interactions using
+a class-based menu system.
+
+- Repository: `GitHub <https://github.com/neonjonn/lightbulb-neon>`_
+
+- Documentation: `Readthedocs <https://lightbulb-neon.readthedocs.io/en/latest/>`_
+
+Quick Examples
+--------------
+
+Component menu:
+
+.. code-block:: python
+
+    import lightbulb
+    import neon
+
+    class Menu(neon.ComponentMenu):
+        @neon.button("earth", "earth_button", hikari.ButtonStyle.SUCCESS, emoji="\N{DECIDUOUS TREE}")
+        async def earth(self, button: neon.Button) -> None:
+            await self.edit_msg(f"{button.emoji} - {button.custom_id}")
+
+        @neon.option("Water", "water", emoji="\N{DROPLET}")
+        @neon.option("Fire", "fire", emoji="\N{FIRE}")
+        @neon.select_menu("sample_select_menu", "Pick fire or water!")
+        async def select_menu_test(self, values: list) -> None:
+            await self.edit_msg(f"You chose: {values[0]}!")
+
+        @neon.on_timeout(disable_components=True)
+        async def on_timeout(self) -> None:
+            await self.edit_msg("\N{ALARM CLOCK} Timed out!")
+
+
+    @lightbulb.command("neon", "Check out Neon's component builder!")
+    @lightbulb.implements(lightbulb.SlashCommand, lightbulb.PrefixCommand)
+    async def neon_command(ctx: lightbulb.Context) -> None:
+        menu = Menu(ctx, timeout=30)
+        msg = await ctx.respond("Bar", components=menu.build())
+        await menu.run(msg)
+
+----
+
+lightbulb-wtf
+=============
+
+A library written by thomm.o which provides a completely different method of declaring commands. This library started
+out as a joke to see how badly python's syntax could be abused but turned in to a fully functional method of declaring
+lightbulb commands.
+
+- Repository: `GitHub <https://github.com/tandemdude/lightbulb-wtf>`_
+
+- Documentation: `Readthedocs <https://lightbulb-wtf.readthedocs.io/en/latest/>`_
+
+Quick Examples
+--------------
+
+Declaring commands:
+
+.. code-block:: python
+
+    import lightbulb
+    from wtf import Command, Options, Option
+    from wtf import Implements, Name, Description, Executes
+
+    echo = Command[
+        Implements[lightbulb.SlashCommand, lightbulb.PrefixCommand],
+        Name["echo"],
+        Description["repeats the given text"],
+        Options[
+            Option[
+                Name["text"],
+                Description["text to repeat"],
+            ],
+        ],
+        Executes[lambda ctx: ctx.respond(ctx.options.text)],
+    ]
+
+----
+
+More coming soon (hopefully).

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -54,20 +54,7 @@ Helpful Resources:
 
 - :ref:`guides`
 
-Extension Libraries:
---------------------
-
-If you have written an extension library that you would like to have added to this list, please contact thomm.o#8637
-on discord.
-
-- `lightbulb-filament <https://github.com/tandemdude/filament>`_ - a hikari-lightbulb extension library written by thomm.o
-  which provides various utility methods and extensions you can easily integrate into your bots, as well as different command
-  declaration syntax using a similar class-based method to hikari-lightbulb V1s slash commands and a template system
-  allowing you to quickly create a bot project. See the `documentation <https://filament.readthedocs.io/en/latest/>`_ for how to get started.
-
-- `lightbulb-neon <https://github.com/neonjonn/lightbulb-neon>`_ - a hikari-lightbulb extension library written by NeonJonn
-  allowing you to easily create component (button and select) interactions using a class-based menu definition system. See
-  the `documentation <https://lightbulb-neon.readthedocs.io/en/latest/>`_ for how to get started.
+- :ref:`extension-libs`
 
 Contributors:
 -------------
@@ -102,5 +89,6 @@ Index:
    guide
    api-reference
    changelog
+   extension-libs
 
 * :ref:`genindex`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -45,7 +45,8 @@ syntax. I recommend taking a look at both Lightbulb and Tanjun before choosing w
 
 `View Tanjun on GitHub <https://github.com/FasterSpeeding/Tanjun>`_
 
-**Helpful Resources:**
+Helpful Resources:
+------------------
 
 - `Hikari Documentation <https://www.hikari-py.dev/>`_
 
@@ -53,9 +54,23 @@ syntax. I recommend taking a look at both Lightbulb and Tanjun before choosing w
 
 - :ref:`guides`
 
-- `Filament (hikari-lightbulb extension library) <https://filament.readthedocs.io/en/latest/>`_
+Extension Libraries:
+--------------------
 
-**Contributors:**
+If you have written an extension library that you would like to have added to this list, please contact thomm.o#8637
+on discord.
+
+- `lightbulb-filament <https://github.com/tandemdude/filament>`_ - a hikari-lightbulb extension library written by thomm.o
+  which provides various utility methods and extensions you can easily integrate into your bots, as well as different command
+  declaration syntax using a similar class-based method to hikari-lightbulb V1s slash commands and a template system
+  allowing you to quickly create a bot project. See the `documentation <https://filament.readthedocs.io/en/latest/>`_ for how to get started.
+
+- `lightbulb-neon <https://github.com/neonjonn/lightbulb-neon>`_ - a hikari-lightbulb extension library written by NeonJonn
+  allowing you to easily create component (button and select) interactions using a class-based menu definition system. See
+  the `documentation <https://lightbulb-neon.readthedocs.io/en/latest/>`_ for how to get started.
+
+Contributors:
+-------------
 
 - `thomm.o#8637 (creator) <https://github.com/tandemdude>`_
 
@@ -77,7 +92,8 @@ syntax. I recommend taking a look at both Lightbulb and Tanjun before choosing w
 
 - `Parafoxia#1911 <https://github.com/parafoxia>`_
 
-**Index:**
+Index:
+------
 
 .. toctree::
    :maxdepth: 2

--- a/lightbulb/__init__.py
+++ b/lightbulb/__init__.py
@@ -61,6 +61,7 @@ __all__ = [
     "InviteConverter",
     "LightbulbError",
     "LightbulbEvent",
+    "LightbulbStartedEvent",
     "MemberConverter",
     "MessageCommand",
     "MessageCommandCompletionEvent",
@@ -173,4 +174,4 @@ from lightbulb.events import *
 from lightbulb.help_command import *
 from lightbulb.plugins import *
 
-__version__ = "2.0.4"
+__version__ = "2.1.0"

--- a/lightbulb/app.py
+++ b/lightbulb/app.py
@@ -344,7 +344,6 @@ class BotApp(hikari.GatewayBot):
 
         try:
             await internal.manage_application_commands(self)
-            await self.dispatch(events.LightbulbStartedEvent(app=self))
         except hikari.ForbiddenError as exc:
             error_msg = str(exc)
             match = _APPLICATION_CMD_ERROR_REGEX.search(error_msg)
@@ -352,6 +351,8 @@ class BotApp(hikari.GatewayBot):
             raise errors.ApplicationCommandCreationFailed(
                 f"Application command creation failed for guild {guild_id!r}. Is your bot in the guild and was it invited with the 'application.commands' scope?"
             ) from exc
+        finally:
+            await self.dispatch(events.LightbulbStartedEvent(app=self))
 
     @staticmethod
     def _get_events_for_application_command(

--- a/lightbulb/app.py
+++ b/lightbulb/app.py
@@ -344,6 +344,7 @@ class BotApp(hikari.GatewayBot):
 
         try:
             await internal.manage_application_commands(self)
+            await self.dispatch(events.LightbulbStartedEvent(app=self))
         except hikari.ForbiddenError as exc:
             error_msg = str(exc)
             match = _APPLICATION_CMD_ERROR_REGEX.search(error_msg)

--- a/lightbulb/commands/base.py
+++ b/lightbulb/commands/base.py
@@ -372,6 +372,7 @@ class Command(abc.ABC):
         Invokes the command under the given context. All checks and cooldowns will be processed
         prior to invocation.
         """
+        context._invoked = self
         await self.evaluate_checks(context)
         await self.evaluate_cooldowns(context)
         await self(context)

--- a/lightbulb/commands/prefix.py
+++ b/lightbulb/commands/prefix.py
@@ -92,6 +92,7 @@ class PrefixCommand(base.Command):
         return sig
 
     async def invoke(self, context: context_.base.Context) -> None:
+        context._invoked = self
         await self.evaluate_checks(context)
         await self.evaluate_cooldowns(context)
         assert isinstance(context, context_.prefix.PrefixContext)
@@ -116,6 +117,7 @@ class PrefixSubCommand(PrefixCommand, base.SubCommandTrait):
         return f"{self.parent.qualname} {self.name}"
 
     async def invoke(self, context: context_.base.Context, *, arg_buffer: str = "") -> None:
+        context._invoked = self
         assert isinstance(context, context_.prefix.PrefixContext)
         context._parser = type(context._parser)(context, arg_buffer)
         context._parser.options = list(self.options.values())
@@ -142,6 +144,7 @@ class PrefixSubGroup(PrefixCommand, PrefixGroupMixin, base.SubCommandTrait):
         return f"{self.parent.qualname} {self.name}"
 
     async def invoke(self, context: context_.base.Context, *, arg_buffer: str = "") -> None:
+        context._invoked = self
         subcmd, remainder = self.maybe_resolve_subcommand(arg_buffer)
         if subcmd is not None:
             await subcmd.invoke(context, arg_buffer=remainder)
@@ -173,6 +176,7 @@ class PrefixCommandGroup(PrefixCommand, PrefixGroupMixin):
         self.create_subcommands(self._raw_subcommands, app)
 
     async def invoke(self, context: context_.base.Context) -> None:
+        context._invoked = self
         assert isinstance(context, context_.prefix.PrefixContext) and context.event.message.content is not None
 
         subcmd, remainder = self.maybe_resolve_subcommand(

--- a/lightbulb/context/base.py
+++ b/lightbulb/context/base.py
@@ -110,13 +110,14 @@ class Context(abc.ABC):
         app (:obj:`~.app.BotApp`): The ``BotApp`` instance that the context is linked to.
     """
 
-    __slots__ = ("_app", "_responses", "_responded", "_deferred")
+    __slots__ = ("_app", "_responses", "_responded", "_deferred", "_invoked")
 
     def __init__(self, app: app_.BotApp):
         self._app = app
         self._responses: t.List[ResponseProxy] = []
         self._responded: bool = False
         self._deferred: bool = False
+        self._invoked: t.Optional[commands.base.Command] = None
 
     @abc.abstractmethod
     async def _maybe_defer(self) -> None:
@@ -223,8 +224,13 @@ class Context(abc.ABC):
     @property
     @abc.abstractmethod
     def command(self) -> t.Optional[commands.base.Command]:
-        """The command object that the context is for."""
+        """The root command object that the context is for."""
         ...
+
+    @property
+    def invoked(self) -> t.Optional[commands.base.Command]:
+        """The command or subcommand that was invoked in this context."""
+        return self._invoked
 
     @abc.abstractmethod
     def get_channel(self) -> t.Optional[t.Union[hikari.GuildChannel, hikari.Snowflake]]:

--- a/lightbulb/decorators.py
+++ b/lightbulb/decorators.py
@@ -53,7 +53,9 @@ def implements(
     return decorate
 
 
-def command(name: str, description: str, **kwargs: t.Any) -> t.Callable[[CommandCallbackT], commands.base.CommandLike]:
+def command(
+    name: str, description: str, *, cls: t.Type[commands.base.CommandLike] = commands.base.CommandLike, **kwargs: t.Any
+) -> t.Callable[[CommandCallbackT], commands.base.CommandLike]:
     """
     Second order decorator that converts the decorated function into a :obj:`~.commands.base.CommandLike` object.
 
@@ -80,16 +82,23 @@ def command(name: str, description: str, **kwargs: t.Any) -> t.Callable[[Command
         hidden (:obj:`bool`): Whether or not to hide the command from the help command. Defaults to ``False``.
         inherit_checks (:obj:`bool`): Whether or not the command should inherit checks from the parent group. Only
             affects subcommands. Defaults to ``False``.
+        cls (Type[:obj:`~.commands.base.CommandLike`]): ``CommandLike`` class to instantiate from this decorator.
+            Defaults to :obj:`~.commands.base.CommandLike`.
     """
 
     def decorate(func: CommandCallbackT) -> commands.base.CommandLike:
-        return commands.base.CommandLike(func, name, description, **kwargs)
+        return cls(func, name, description, **kwargs)
 
     return decorate
 
 
 def option(
-    name: str, description: str, type: t.Type[t.Any] = str, **kwargs: t.Any
+    name: str,
+    description: str,
+    type: t.Type[t.Any] = str,
+    *,
+    cls: t.Type[commands.base.OptionLike] = commands.base.OptionLike,
+    **kwargs: t.Any,
 ) -> t.Callable[[commands.base.CommandLike], commands.base.CommandLike]:
     """
     Second order decorator that adds an option to the decorated :obj:`~.commands.base.CommandLike`
@@ -110,13 +119,15 @@ def option(
         default (UndefinedOr[Any]): The default value for the option. Defaults to :obj:`~hikari.undefined.UNDEFINED`.
         modifier (:obj:`~.commands.base.OptionModifier`): Modifier controlling how the option should be parsed. Defaults
             to ``OptionModifier.NONE``.
+        cls (Type[:obj:`~.commands.base.OptionLike`]): ``OptionLike`` class to instantiate from this decorator. Defaults
+            to :obj:`~.commands.base.OptionLike`.
     """
     kwargs.setdefault("required", kwargs.get("default", hikari.UNDEFINED) is hikari.UNDEFINED)
     if not kwargs["required"]:
         kwargs.setdefault("default", None)
 
     def decorate(c_like: commands.base.CommandLike) -> commands.base.CommandLike:
-        c_like.options[name] = commands.base.OptionLike(name, description, type, **kwargs)
+        c_like.options[name] = cls(name, description, type, **kwargs)
         return c_like
 
     return decorate

--- a/lightbulb/events.py
+++ b/lightbulb/events.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 __all__ = [
     "LightbulbEvent",
+    "LightbulbStartedEvent",
     "CommandErrorEvent",
     "PrefixCommandErrorEvent",
     "PrefixCommandInvocationEvent",
@@ -63,6 +64,11 @@ class LightbulbEvent(hikari.Event, abc.ABC):
     def bot(self) -> app_.BotApp:
         """BotApp instance for this event. Alias for :obj:`~LightbulbEvent.app`."""
         return self.app
+
+
+@attr.s(slots=True, weakref_slot=False)
+class LightbulbStartedEvent(LightbulbEvent):
+    """Event dispatched after the application commands have been managed."""
 
 
 @attr.s(slots=True, weakref_slot=False)

--- a/setup.py
+++ b/setup.py
@@ -69,9 +69,6 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=parse_requirements_file("requirements.txt"),
-    extras_require={
-        "filament": ["lightbulb-filament==0.*"]
-    },
     python_requires=">=3.8.0,<3.11",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
### Summary
- Add `lightbulb.events.LightbulbStartedEvent`.

- Add `cls` kwarg to `lightbulb.decorators.command` and `lightbulb.decorators.option` to allow you to use your
  own `CommandLike` and `OptionLike` classes.

- Add `lightbulb.context.Context.invoked`.

- Implement ability to use namespace packages to extend lightbulb.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
