### PR TITLE
2.1.1

### DIFF
--- a/docs/source/changelogs/v2-changelog.rst
+++ b/docs/source/changelogs/v2-changelog.rst
@@ -6,6 +6,14 @@ Below are all the changelogs for the stable versions of hikari-lightbulb (versio
 
 ----
 
+Version 2.1.1
+=============
+
+- Fix error raised when exclusive checks are added to any object.
+
+- Subclasses of :obj:`lightbulb.errors.CheckFailure` are no longer wrapped in an additional :obj:`lightbulb.errors.CheckFailure`
+  object when a check fails.
+
 Version 2.1.0
 =============
 

--- a/lightbulb/__init__.py
+++ b/lightbulb/__init__.py
@@ -174,4 +174,4 @@ from lightbulb.events import *
 from lightbulb.help_command import *
 from lightbulb.plugins import *
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"

--- a/lightbulb/checks.py
+++ b/lightbulb/checks.py
@@ -61,6 +61,9 @@ class _ExclusiveCheck:
     def __init__(self, *checks: "Check") -> None:
         self._checks = list(checks)
 
+    def __repr__(self) -> str:
+        return f"ExclusiveCheck({', '.join(repr(c) for c in self._checks)})"
+
     def __or__(self, other: t.Union["_ExclusiveCheck", "Check"]) -> "_ExclusiveCheck":
         if isinstance(other, _ExclusiveCheck):
             self._checks.extend(other._checks)

--- a/lightbulb/checks.py
+++ b/lightbulb/checks.py
@@ -96,6 +96,13 @@ class _ExclusiveCheck:
     def __call__(self, context: context_.base.Context) -> t.Coroutine[t.Any, t.Any, bool]:
         return self._evaluate(context)
 
+    def add_to_object_hook(
+        self, obj: t.Union[plugins.Plugin, app.BotApp, commands.base.CommandLike]
+    ) -> t.Union[plugins.Plugin, app.BotApp, commands.base.CommandLike]:
+        for check in self._checks:
+            check.add_to_object_hook(obj)
+        return obj
+
 
 class Check:
     """

--- a/lightbulb/commands/base.py
+++ b/lightbulb/commands/base.py
@@ -402,8 +402,11 @@ class Command(abc.ABC):
                 if not result:
                     failed_checks.append(errors.CheckFailure(f"Check {check.__name__} failed for command {self.name}"))
             except Exception as ex:
-                error = errors.CheckFailure(str(ex))
-                error.__cause__ = ex
+                if not isinstance(ex, errors.CheckFailure):
+                    error = errors.CheckFailure(str(ex))
+                    error.__cause__ = ex
+                else:
+                    error = ex
                 failed_checks.append(error)
 
         if len(failed_checks) > 1:


### PR DESCRIPTION
### Summary
- Fix error raised when exclusive checks are added to any object.

- Subclasses of `CheckFailure` are no longer wrapped in an additional `CheckFailure`
  object when a check fails.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
