### PR TITLE
1.2.3

### DIFF
--- a/docs/source/changelogs/v2-changelog.rst
+++ b/docs/source/changelogs/v2-changelog.rst
@@ -15,6 +15,8 @@ Version 2.1.2
 
 - Fix :obj:`lightbulb.errors.ExtensionNotFound` error being raised when an import fails in an extension being loaded.
 
+- Add ``default_enabled_guilds`` argument to the :obj:`lightbulb.plugins.Plugin` class.
+
 Version 2.1.1
 =============
 

--- a/docs/source/changelogs/v2-changelog.rst
+++ b/docs/source/changelogs/v2-changelog.rst
@@ -6,6 +6,15 @@ Below are all the changelogs for the stable versions of hikari-lightbulb (versio
 
 ----
 
+Version 2.1.3
+=============
+
+- Fix plugin checks not propagating correctly for subcommands.
+
+- Add additional validation to ensure correct decorator order.
+
+- Add :obj:`lightbulb.commands.base.OptionLike.min_value` and :obj:`lightbulb.commands.base.OptionLike.max_value`.
+
 Version 2.1.2
 =============
 

--- a/docs/source/guides/commands.rst
+++ b/docs/source/guides/commands.rst
@@ -292,12 +292,16 @@ For example:
 
     import lightbulb
 
+    # OPTIONAL: Converting the check function into a Check object
+    @lightbulb.Check
     # Defining the custom check function
     def check_author_is_me(context: lightbulb.Context) -> bool:
         # Returns True if the author's ID is the same as the given one
         return context.author.id == 1455657467
 
     # Adding the check to a command
+    @lightbulb.add_checks(check_author_is_me)
+    # Or if you do not use the @lightbulb.Check decorator
     @lightbulb.add_checks(lightbulb.Check(check_author_is_me))
 
 

--- a/docs/source/guides/commands.rst
+++ b/docs/source/guides/commands.rst
@@ -152,6 +152,12 @@ Lightbulb provides the :obj:`lightbulb.decorators.option` decorator for this pur
   string without parsing it) and ``GREEDY`` (consumes and converts arguments until either the argument string is exhausted
   or argument conversion fails).
 
+- ``min_value`` (optional): The minimum value permitted for this option (inclusive). Only available if the option type
+  is numeric (integer or float).
+
+- ``max_value`` (optional): The maximum value permitted for this option (inclusive). Only available if the option type
+  is numeric (integer or float).
+
 **For example:**
 
 .. code-block:: python

--- a/lightbulb/__init__.py
+++ b/lightbulb/__init__.py
@@ -174,4 +174,4 @@ from lightbulb.events import *
 from lightbulb.help_command import *
 from lightbulb.plugins import *
 
-__version__ = "2.1.2"
+__version__ = "2.1.3"

--- a/lightbulb/commands/base.py
+++ b/lightbulb/commands/base.py
@@ -179,6 +179,7 @@ class CommandLike:
     parser: t.Optional[t.Type[parser_.BaseParser]] = None
     """The argument parser to use for prefix commands."""
     cooldown_manager: t.Optional[cooldowns.CooldownManager] = None
+    """The cooldown manager for the command."""
     help_getter: t.Optional[t.Callable[[Command, context_.base.Context], str]] = None
     """The function to call to get the command's long help text."""
     auto_defer: bool = False
@@ -268,7 +269,7 @@ class Command(abc.ABC):
         "checks",
         "error_handler",
         "parent",
-        "plugin",
+        "_plugin",
         "aliases",
         "parser",
         "cooldown_manager",
@@ -282,6 +283,7 @@ class Command(abc.ABC):
     def __init__(self, app: app_.BotApp, initialiser: CommandLike) -> None:
         self._initialiser = initialiser
         self._help_getter = initialiser.help_getter
+        self._plugin: t.Optional[plugins.Plugin] = None
         self.app: app_.BotApp = app
         """The ``BotApp`` instance the command is registered to."""
         self.callback: t.Callable[[context_.base.Context], t.Coroutine[t.Any, t.Any, None]] = initialiser.callback
@@ -300,8 +302,6 @@ class Command(abc.ABC):
         """The error handler function for the command."""
         self.parent: t.Optional[Command] = None
         """The parent for the command."""
-        self.plugin: t.Optional[plugins.Plugin] = None
-        """The plugin that the command belongs to."""
         self.aliases: t.Sequence[str] = initialiser.aliases
         """The aliases for the command. This value means nothing for application commands."""
         self.parser: t.Optional[t.Type[parser_.BaseParser]] = initialiser.parser
@@ -329,6 +329,18 @@ class Command(abc.ABC):
 
     def _validate_attributes(self) -> None:
         pass
+
+    def _set_plugin(self, pl: plugins.Plugin) -> None:
+        self._plugin = pl
+
+    @property
+    def plugin(self) -> t.Optional[plugins.Plugin]:
+        """The plugin that the command belongs to."""
+        return self._plugin
+
+    @plugin.setter
+    def plugin(self, pl: plugins.Plugin) -> None:
+        self._set_plugin(pl)
 
     @property
     def bot(self) -> app_.BotApp:

--- a/lightbulb/decorators.py
+++ b/lightbulb/decorators.py
@@ -95,7 +95,7 @@ def command(
 def option(
     name: str,
     description: str,
-    type: t.Type[t.Any] = str,
+    type: t.Any = str,
     *,
     cls: t.Type[commands.base.OptionLike] = commands.base.OptionLike,
     **kwargs: t.Any,
@@ -107,7 +107,7 @@ def option(
     Args:
         name (:obj:`str`): The name of the option.
         description (:obj:`str`): The description of the option.
-        type (Type[Any]): The type of the option. This will be used as the converter for prefix commands.
+        type (Any): The type of the option. This will be used as the converter for prefix commands.
 
     Keyword Args:
         required (:obj:`bool`): Whether or not this option is required. This will be inferred from whether or not
@@ -119,6 +119,10 @@ def option(
         default (UndefinedOr[Any]): The default value for the option. Defaults to :obj:`~hikari.undefined.UNDEFINED`.
         modifier (:obj:`~.commands.base.OptionModifier`): Modifier controlling how the option should be parsed. Defaults
             to ``OptionModifier.NONE``.
+        min_value (Optional[Union[:obj:`float`, :obj:`int`]]): The minimum value permitted for this option (inclusive).
+            Only available if the option type is numeric (integer or float).
+        max_value (Optional[Union[:obj:`float`, :obj:`int`]]): The maximum value permitted for this option (inclusive).
+            Only available if the option type is numeric (integer or float).
         cls (Type[:obj:`~.commands.base.OptionLike`]): ``OptionLike`` class to instantiate from this decorator. Defaults
             to :obj:`~.commands.base.OptionLike`.
     """
@@ -221,7 +225,7 @@ def add_cooldown(
         bucket (Type[:obj:`~.cooldowns.Bucket`]): The bucket to use for cooldowns.
 
     Keyword Args:
-        callback (Callable[[:obj:`~.context.base.Context], Union[:obj:`~.cooldowns.Bucket`, Coroutine[Any, Any, :obj:`~.cooldowns.Bucket`): Callable
+        callback (Callable[[:obj:`~.context.base.Context], Union[:obj:`~.cooldowns.Bucket`, Coroutine[Any, Any, :obj:`~.cooldowns.Bucket`]]]): Callable
             that takes the context the command was invoked under and returns the appropriate bucket object to use for
             cooldowns in the context.
         cls (Type[:obj:`~.cooldowns.CooldownManager`]): The cooldown manager class to use. Defaults to

--- a/lightbulb/decorators.py
+++ b/lightbulb/decorators.py
@@ -127,6 +127,9 @@ def option(
         kwargs.setdefault("default", None)
 
     def decorate(c_like: commands.base.CommandLike) -> commands.base.CommandLike:
+        if not isinstance(c_like, commands.base.CommandLike):
+            raise SyntaxError("'option' decorator must be above the 'command' decorator")
+
         c_like.options[name] = cls(name, description, type, **kwargs)
         return c_like
 
@@ -145,6 +148,9 @@ def add_checks(
     """
 
     def decorate(c_like: commands.base.CommandLike) -> commands.base.CommandLike:
+        if not isinstance(c_like, commands.base.CommandLike):
+            raise SyntaxError("'add_checks' decorator must be above the 'command' decorator")
+
         new_checks = [*c_like.checks, *cmd_checks]
         c_like.checks = new_checks
 
@@ -170,6 +176,9 @@ def check_exempt(
     """
 
     def decorate(c_like: commands.base.CommandLike) -> commands.base.CommandLike:
+        if not isinstance(c_like, commands.base.CommandLike):
+            raise SyntaxError("'check_exempt' decorator must be above the 'command' decorator")
+
         c_like.check_exempt = predicate
         return c_like
 
@@ -231,6 +240,9 @@ def add_cooldown(
         raise TypeError("Invalid arguments - either provided all of the args length,uses,bucket or the kwarg callback")
 
     def decorate(c_like: commands.base.CommandLike) -> commands.base.CommandLike:
+        if not isinstance(c_like, commands.base.CommandLike):
+            raise SyntaxError("'add_cooldown' decorator must be above the 'command' decorator")
+
         c_like.cooldown_manager = cls(getter)
         return c_like
 
@@ -260,6 +272,9 @@ def set_help(
         raise ValueError("Either help text/callable or docstring=True must be provided")
 
     def decorate(c_like: commands.base.CommandLike) -> commands.base.CommandLike:
+        if not isinstance(c_like, commands.base.CommandLike):
+            raise SyntaxError("'set_help' decorator must be above the 'command' decorator")
+
         if isinstance(text, str):
             getter = lambda _, __: text
         elif docstring:

--- a/lightbulb/plugins.py
+++ b/lightbulb/plugins.py
@@ -170,7 +170,6 @@ class Plugin:
                     continue
 
                 cmd._validate_attributes()
-
                 cmd.plugin = self
                 self._all_commands.append(cmd)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-hikari~=2.0.0.dev104
+hikari~=2.0.0.dev105


### PR DESCRIPTION
### Summary
- Fix plugin checks not propagating correctly for subcommands.

- Add additional validation to ensure correct decorator order.

- Add `lightbulb.commands.base.OptionLike.min_value` and `lightbulb.commands.base.OptionLike.max_value`.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.

### Related issues
#186 
