### PR TITLE
Add ability to use kwargs to initialise a task using a CronTrigger

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 graft lightbulb
 include requirements.txt
+include crontrigger_requirements.txt
 include setup.py
 include README.md
 include pyproject.toml

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 -r docs_requirements.txt
+-r crontrigger_requirements.txt
 nox~=2022.1.7

--- a/lightbulb/ext/tasks/triggers.py
+++ b/lightbulb/ext/tasks/triggers.py
@@ -68,24 +68,24 @@ try:
         """
         A crontab-based task trigger. Tasks will be run dependent on the given crontab.
 
-        .. note::
+        Note:
             Keyword arguments are only used if no crontab expression is passed.
 
         Args:
-            crontab (:obj:`str` | :obj:`None`): Schedule that task executions will follow.
+            crontab (Optional[:obj:`str`]): Schedule that task executions will follow.
 
         Keyword Args:
-            month (:obj:`int` | :obj:`str` | :obj:`None`):
+            month (Optional[Union[:obj:`int`, :obj:`str`]]):
                 The month(s) that the task will be executed.
-            day (:obj:`int` | :obj:`str` | :obj:`None`):
+            day (Optional[Union[:obj:`int`, :obj:`str`]]):
                 The day(s) that the task will be executed.
-            day_of_week (:obj:`int` | :obj:`str` | :obj:`None`):
+            day_of_week (Optional[Union[:obj:`int`, :obj:`str`]]):
                 The day(s) of the week that the task will be executed.
-            hour (:obj:`int` | :obj:`str` | :obj:`None`):
+            hour (Optional[Union[:obj:`int`, :obj:`str`]]):
                 The hour(s) that the task will be executed.
-            minute (:obj:`int` | :obj:`str` | :obj:`None`):
+            minute (Optional[Union[:obj:`int`, :obj:`str`]]):
                 The minute(s) that the task will be executed.
-            second (:obj:`int` | :obj:`str` | :obj:`None`):
+            second (Optional[Union[:obj:`int`, :obj:`str`]]):
                 The second(s) that the task will be executed.
 
         Note:
@@ -98,7 +98,7 @@ try:
 
         def __init__(
             self,
-            crontab: str | None = None,
+            crontab: t.Union[str, None] = None,
             /,
             *,
             month: _CT = None,

--- a/lightbulb/ext/tasks/triggers.py
+++ b/lightbulb/ext/tasks/triggers.py
@@ -104,38 +104,16 @@ if t.TYPE_CHECKING or _CRON_AVAILABLE:
         __slots__ = ("_croniter",)
 
         @t.overload
-        def __init__(self, crontab: str) -> None:
+        def __init__(self, crontab: str, /) -> None:
             ...
 
         @t.overload
-        def __init__(
-            self,
-            *,
-            month: _CT = None,
-            day: _CT = None,
-            day_of_week: _CT = None,
-            hour: _CT = None,
-            minute: _CT = None,
-            second: _CT = None,
-        ) -> None:
+        def __init__(self, /, **kwargs: _CT) -> None:
             ...
 
-        def __init__(
-            self,
-            crontab: t.Union[str, None] = None,
-            /,
-            *,
-            month: _CT = None,
-            day: _CT = None,
-            day_of_week: _CT = None,
-            hour: _CT = None,
-            minute: _CT = None,
-            second: _CT = None,
-        ) -> None:
+        def __init__(self, crontab: t.Optional[str] = None, /, **kwargs: _CT) -> None:
             if not crontab:
-                crontab = (
-                    f"{minute or '*'} {hour or '*'} {day or '*'} {month or '*'} {day_of_week or '*'} {second or 0}"
-                )
+                crontab = f"{kwargs.get('minute', '*')} {kwargs.get('hour', '*')} {kwargs.get('day', '*')} {kwargs.get('month', '*')} {kwargs.get('day_of_week', '*')} {kwargs.get('second', 0)}"
 
             self._croniter = croniter.croniter(crontab, datetime.datetime.now(datetime.timezone.utc))
 
@@ -147,7 +125,7 @@ if t.TYPE_CHECKING or _CRON_AVAILABLE:
 
 else:
 
-    class CronTrigger(Trigger):  # type: ignore[no-redef]
+    class CronTrigger(Trigger):
         __slots__ = ()
 
         def __init__(self, _: str) -> None:

--- a/lightbulb/ext/tasks/triggers.py
+++ b/lightbulb/ext/tasks/triggers.py
@@ -21,6 +21,9 @@ __all__ = ["Trigger", "UniformTrigger", "CronTrigger"]
 
 import abc
 import datetime
+import typing as t
+
+_CT = t.Union[int, str, None]
 
 
 class Trigger(abc.ABC):
@@ -65,8 +68,25 @@ try:
         """
         A crontab-based task trigger. Tasks will be run dependent on the given crontab.
 
+        .. note::
+            Keyword arguments are only used if no crontab expression is passed.
+
         Args:
-            crontab (:obj:`str`): Schedule that task executions will follow.
+            crontab (:obj:`str` | :obj:`None`): Schedule that task executions will follow.
+
+        Keyword Args:
+            month (:obj:`int` | :obj:`str` | :obj:`None`):
+                The month(s) that the task will be executed.
+            day (:obj:`int` | :obj:`str` | :obj:`None`):
+                The day(s) that the task will be executed.
+            day_of_week (:obj:`int` | :obj:`str` | :obj:`None`):
+                The day(s) of the week that the task will be executed.
+            hour (:obj:`int` | :obj:`str` | :obj:`None`):
+                The hour(s) that the task will be executed.
+            minute (:obj:`int` | :obj:`str` | :obj:`None`):
+                The minute(s) that the task will be executed.
+            second (:obj:`int` | :obj:`str` | :obj:`None`):
+                The second(s) that the task will be executed.
 
         Note:
             This trigger is only available when installing lightbulb with the ``[crontrigger]`` option.
@@ -76,7 +96,23 @@ try:
 
         __slots__ = ("_croniter",)
 
-        def __init__(self, crontab: str) -> None:
+        def __init__(
+            self,
+            crontab: str | None = None,
+            /,
+            *,
+            month: _CT = None,
+            day: _CT = None,
+            day_of_week: _CT = None,
+            hour: _CT = None,
+            minute: _CT = None,
+            second: _CT = None,
+        ) -> None:
+            if not crontab:
+                crontab = (
+                    f"{minute or '*'} {hour or '*'} {day or '*'} {month or '*'} {day_of_week or '*'} {second or 0}"
+                )
+
             self._croniter = croniter.croniter(crontab, datetime.datetime.now(datetime.timezone.utc))
 
         def get_interval(self) -> float:

--- a/lightbulb/ext/tasks/triggers.py
+++ b/lightbulb/ext/tasks/triggers.py
@@ -23,6 +23,14 @@ import abc
 import datetime
 import typing as t
 
+try:
+    import croniter
+
+    _CRON_AVAILABLE = True
+
+except ModuleNotFoundError:
+    _CRON_AVAILABLE = False
+
 _CT = t.Union[int, str, None]
 
 
@@ -61,8 +69,7 @@ class UniformTrigger(Trigger):
         return self._interval
 
 
-try:
-    import croniter
+if t.TYPE_CHECKING or _CRON_AVAILABLE:
 
     class CronTrigger(Trigger):
         """
@@ -138,7 +145,7 @@ try:
             )
             return difference.total_seconds()
 
-except ModuleNotFoundError:
+else:
 
     class CronTrigger(Trigger):  # type: ignore[no-redef]
         __slots__ = ()

--- a/lightbulb/ext/tasks/triggers.py
+++ b/lightbulb/ext/tasks/triggers.py
@@ -96,6 +96,23 @@ try:
 
         __slots__ = ("_croniter",)
 
+        @t.overload
+        def __init__(self, crontab: str) -> None:
+            ...
+
+        @t.overload
+        def __init__(
+            self,
+            *,
+            month: _CT = None,
+            day: _CT = None,
+            day_of_week: _CT = None,
+            hour: _CT = None,
+            minute: _CT = None,
+            second: _CT = None,
+        ) -> None:
+            ...
+
         def __init__(
             self,
             crontab: t.Union[str, None] = None,

--- a/setup.py
+++ b/setup.py
@@ -69,9 +69,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=parse_requirements_file("requirements.txt"),
-    extras_require={
-        "crontrigger": parse_requirements_file("crontrigger_requirements.txt")
-    },
+    extras_require={"crontrigger": parse_requirements_file("crontrigger_requirements.txt")},
     python_requires=">=3.8.0,<3.11",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
### Summary
This PR adds the ability to schedule tasks using kwargs rather than the crontab format.

For example...
```py
@task(CronTrigger("*/15 7-10 10 * *"))
```
...can now be written as:
```py
@task(CronTrigger(day=10, hour="7-10", minute="*/15"))
```

### Checklist
- [x] I have run `nox` and all the pipelines have passed.

### Related issues
None.
