### PR TITLE
ConverterFailure raw_value

### DIFF
--- a/lightbulb/errors.py
+++ b/lightbulb/errors.py
@@ -147,12 +147,14 @@ class ConverterFailure(LightbulbError):
     Error raised when option type conversion fails while prefix command arguments are being parsed.
     """
 
-    __slots__ = ("option",)
+    __slots__ = ("option", "raw_value")
 
-    def __init__(self, *args: t.Any, opt: commands.base.OptionLike) -> None:
+    def __init__(self, *args: t.Any, opt: commands.base.OptionLike, raw: str) -> None:
         super().__init__(*args)
         self.option: commands.base.OptionLike = opt
         """The option that could not be converted."""
+        self.raw_value: str = raw
+        """The value that could not be converted."""
 
 
 class NotEnoughArguments(LightbulbError):

--- a/lightbulb/utils/parser.py
+++ b/lightbulb/utils/parser.py
@@ -212,7 +212,9 @@ class Parser(BaseParser):
         except Exception as e:
             _LOGGER.debug("Failed to convert", exc_info=e)
             if option.required:
-                raise errors.ConverterFailure(f"Conversion failed for option {option.name!r}", opt=option) from e
+                raise errors.ConverterFailure(
+                    f"Conversion failed for option {option.name!r}", opt=option, raw=raw
+                ) from e
 
             self.ctx._options[option.name] = option.default
             _LOGGER.debug("Option has a default value, shifting to the next parameter")


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->
Adds the raw str value of the option that failed to convert.
### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
