### PR TITLE
Fix missing required positional for arg type

### DIFF
--- a/lightbulb/commands/base.py
+++ b/lightbulb/commands/base.py
@@ -594,6 +594,7 @@ class ApplicationCommand(Command, abc.ABC):
         else:
             created_cmd = await self.app.rest.create_context_menu_command(
                 self.app.application,
+                type=cmd_type,
                 **kwargs,
             )
 


### PR DESCRIPTION
### Summary
Fix bug where you can't create menu based commands.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.

### Related issues
[this thread](https://discord.com/channels/574921006817476608/727982024660615198/941070422554845214)
