### PR TITLE
Add CheckFailure.causes

### DIFF
--- a/lightbulb/checks.py
+++ b/lightbulb/checks.py
@@ -88,14 +88,16 @@ class _ExclusiveCheck:
                 return True
             except Exception as ex:
                 if isinstance(ex, errors.CheckFailure) and not ex.__cause__:
-                    ex = errors.CheckFailure(str(ex))
+                    ex = errors.CheckFailure(str(ex), causes=[ex])
                     ex.__cause__ = ex
                 failed.append(ex)
 
         if failed:
             if len(failed) == 1:
                 raise failed[0]
-            raise errors.CheckFailure("None of the exclusive checks passed: " + ", ".join(str(ex) for ex in failed))
+            raise errors.CheckFailure(
+                "None of the exclusive checks passed: " + ", ".join(str(ex) for ex in failed), causes=failed
+            )
         return True
 
     def __call__(self, context: context_.base.Context) -> t.Coroutine[t.Any, t.Any, bool]:

--- a/lightbulb/commands/base.py
+++ b/lightbulb/commands/base.py
@@ -527,7 +527,9 @@ class Command(abc.ABC):
                 failed_checks.append(error)
 
         if len(failed_checks) > 1:
-            raise errors.CheckFailure("Multiple checks failed: " + ", ".join(str(ex) for ex in failed_checks))
+            raise errors.CheckFailure(
+                "Multiple checks failed: " + ", ".join(str(ex) for ex in failed_checks), causes=failed_checks
+            )
         elif failed_checks:
             raise failed_checks[0]
 

--- a/lightbulb/errors.py
+++ b/lightbulb/errors.py
@@ -181,7 +181,7 @@ class CheckFailure(LightbulbError):
 
     def __init__(self, *args: t.Any, causes: t.Optional[t.Sequence[Exception]] = None) -> None:
         super().__init__(*args)
-        self.failed_checks: t.Optional[t.Sequence[Exception]] = causes
+        self.causes: t.Sequence[Exception] = causes or []
 
 
 class InsufficientCache(CheckFailure):

--- a/lightbulb/errors.py
+++ b/lightbulb/errors.py
@@ -173,8 +173,15 @@ class NotEnoughArguments(LightbulbError):
 class CheckFailure(LightbulbError):
     """
     Error raised when a check fails before command invocation. If another error caused this
-    to be raised then you can access it using ``CheckFailure.__cause__``.
+    to be raised then you can access it using ``CheckFailure.__cause__``, or in the case of
+    multiple checks failing, via ``CheckFailure.causes``.
     """
+
+    __slots__ = ("causes",)
+
+    def __init__(self, *args: t.Any, causes: t.Optional[t.Sequence[Exception]] = None) -> None:
+        super().__init__(*args)
+        self.failed_checks: t.Optional[t.Sequence[Exception]] = causes
 
 
 class InsufficientCache(CheckFailure):


### PR DESCRIPTION
### Summary
Add `CheckFailure.causes`, a list of all exceptions that caused the check failed, in the case that multiple exceptions caused `CheckFailure` to occur.

### Checklist
- [x] I have run `nox` and all the pipelines have passed.
