### PR TITLE
Fix slash subcommands when doing pass_options

### DIFF
--- a/lightbulb/commands/base.py
+++ b/lightbulb/commands/base.py
@@ -454,8 +454,8 @@ class Command(abc.ABC):
 
     async def __call__(self, context: context_.base.Context, **kwargs: t.Any) -> None:
         if self.pass_options:
-            for opt in context.raw_options:
-                kwargs.setdefault(opt, context.raw_options[opt])
+            for opt in context.options._options:
+                kwargs.setdefault(opt, context.options._options[opt])
         return await self.callback(context, **kwargs)
 
     def _validate_attributes(self) -> None:

--- a/lightbulb/commands/base.py
+++ b/lightbulb/commands/base.py
@@ -454,8 +454,8 @@ class Command(abc.ABC):
 
     async def __call__(self, context: context_.base.Context, **kwargs: t.Any) -> None:
         if self.pass_options:
-            for opt in context.options._options:
-                kwargs.setdefault(opt, context.options._options[opt])
+            for opt, value in context.options._options.items():
+                kwargs.setdefault(opt, value)
         return await self.callback(context, **kwargs)
 
     def _validate_attributes(self) -> None:


### PR DESCRIPTION
### Summary
Fix slash subcommands getting the command name passed as an "option" when using `pass_options=True`.

### Checklist
- [ ] I have run `nox` and all the pipelines have passed.
