### PR TITLE
Add example of default guilds in app commands guide

### DIFF
--- a/docs/source/guides/application-commands.rst
+++ b/docs/source/guides/application-commands.rst
@@ -77,6 +77,14 @@ Adding options to slash commands is also identical to how you add options to pre
 
     bot.run()
 
+To create message or user commands you need to add ``commands.MessageCommand`` and ``commands.UserCommand`` respectively
+to the ``@lightbulb.implements`` decorator. You should note that message and user commands cannot take any options, however
+the target of the command will **always** be stored in the option ``target``. Any option decorators added to context menu
+commands will be ignored.
+
+Setting Default Guilds
+======================
+
 Setting default guilds for a single command can be done using the ``guilds`` kwarg in the ``@lightbulb.command`` decorator
 ::
 
@@ -116,7 +124,18 @@ Setting default guilds for all commands at once can be done using the ``default_
 
     bot.run()
 
-To create message or user commands you need to add ``commands.MessageCommand`` and ``commands.UserCommand`` respectively
-to the ``@lightbulb.implements`` decorator. You should note that message and user commands cannot take any options, however
-the target of the command will **always** be stored in the option ``target``. Any option decorators added to context menu
-commands will be ignored.
+Default Guild Resolution Order
+==============================
+
+When handling default guilds, lightbulb will resolve them in the following order:
+
+- Command-specific default guilds (see :obj:`lightbulb.commands.base.CommandLike.guilds`)
+
+- Plugin-specific default guilds (see :obj:`lightbulb.plugins.Plugin.default_enabled_guilds`)
+
+- BotApp default guilds (see :obj:`lightbulb.app.BotApp.default_enabled_guilds`)
+
+.. note::
+
+    If the default guilds are set to an empty tuple or list for a command or plugin, then the
+    command(s) will be global regardless of the downstream default guilds.

--- a/docs/source/guides/application-commands.rst
+++ b/docs/source/guides/application-commands.rst
@@ -34,8 +34,7 @@ For an example slash command, see the `examples directory <https://github.com/ta
 
 .. warning::
     Note that by default, application commands will be **global** unless you specify a set of guilds that they should
-    be created in using ``BotApp.default_enabled_guilds`` or by passing a set of guilds into the ``@lightbulb.command``
-    decorator. Global commands **will** take up to one hour to sync to discord, so it is reccommended that you use
+    be created in (more on this below). Global commands **will** take up to one hour to sync to discord, so it is recommended that you use
     guild-specific commands during development and testing.
 
 ----
@@ -78,6 +77,44 @@ Adding options to slash commands is also identical to how you add options to pre
 
     bot.run()
 
+Setting default guilds for a single command can be done using the ``guilds`` kwarg in the ``@lightbulb.command`` decorator
+::
+
+    import lightbulb
+
+    bot = lightbulb.BotApp(...)
+
+    @bot.command
+    @lightbulb.command("hello", "Says hello", guilds=(123, 456))
+    @lightbulb.implements(lightbulb.SlashCommand)
+    async def echo(ctx: lightbulb.Context) -> None:
+        await ctx.respond("Hi, this command only appears in guilds with ID 123 and 456.")
+
+    bot.run()
+
+Setting default guilds for commands in a ``lightbulb.Plugin`` can be done using the ``default_enabled_guilds`` kwarg in the
+``lightbulb.Plugin`` constructor
+::
+
+    import lightbulb
+
+    example = lightbulb.Plugin("Example", default_enabled_guilds=(123, 456))
+    # All subsequent commands registered to this plugin will be guild commands
+
+Setting default guilds for all commands at once can be done using the ``default_enabled_guilds`` kwarg in the ``BotApp`` constructor
+::
+
+    import lightbulb
+
+    bot = lightbulb.BotApp(..., default_enabled_guilds=(123, 456))
+
+    @bot.command
+    @lightbulb.command("whoami", "Checks who you are")
+    @lightbulb.implements(lightbulb.SlashCommand)
+    async def ping(ctx: lightbulb.Context) -> None:
+        await ctx.respond(ctx.author.username)
+
+    bot.run()
 
 To create message or user commands you need to add ``commands.MessageCommand`` and ``commands.UserCommand`` respectively
 to the ``@lightbulb.implements`` decorator. You should note that message and user commands cannot take any options, however


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->
Adds examples for setting default guilds for app commands to the docs guide.
Examples include using bot constructor, plugin constructor, and command decorator.
This seems to be a common question in the server.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.