### PR TITLE
Strip whitespaces before consuming all the buffer

### DIFF
--- a/lightbulb/utils/parser.py
+++ b/lightbulb/utils/parser.py
@@ -174,6 +174,7 @@ class Parser(BaseParser):
         return self.buffer[prev + 1 : self.idx - 1].replace(f"\\{closing}", closing)
 
     def read_rest(self) -> str:
+        self.skip_ws()
         self.idx = self.n
         return self.buffer[self.prev :]
 


### PR DESCRIPTION
### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.

### Related issues
Fixes #228
