### PR TITLE
Add missing_roles and mode properties to MissingRequiredRole

### DIFF
--- a/lightbulb/checks.py
+++ b/lightbulb/checks.py
@@ -229,8 +229,15 @@ def _has_roles(
 ) -> bool:
     _guild_only(context)
     assert context.member is not None
-    if not check_func([r in context.member.role_ids for r in roles]):
-        raise errors.MissingRequiredRole("You are missing one or more roles required in order to run this command")
+
+    missing_roles = [r for r in roles if r not in context.member.role_ids]
+    # TODO: could potentially optimise any() by stopping the iteration when a required role was found
+    if (check_func is all and missing_roles) or len(missing_roles) == len(roles):
+        raise errors.MissingRequiredRole(
+            "You are missing one or more roles required in order to run this command",
+            roles=missing_roles,
+            mode=check_func,
+        )
     return True
 
 

--- a/lightbulb/errors.py
+++ b/lightbulb/errors.py
@@ -269,6 +269,13 @@ class MissingRequiredRole(CheckFailure):
     Error raised when the member invoking a command is missing one or more of the required roles.
     """
 
+    def __init__(self, *args: t.Any, roles: t.Sequence[int], mode: t.Callable[[t.Sequence[bool]], bool]) -> None:
+        super().__init__(*args)
+        self.missing_roles: t.Sequence[int] = roles
+        "The roles that the member is missing."
+        self.mode = mode
+        "The mode used to check the roles, can be either ``any`` or ``all``."
+
 
 class MissingRequiredPermission(CheckFailure):
     """


### PR DESCRIPTION
### Summary
The mode property is there so that people can format the text based on it.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.

### Related issues
Fix #236 
