### PR TITLE
Make perms util methods account for guild owner

### DIFF
--- a/lightbulb/app.py
+++ b/lightbulb/app.py
@@ -302,7 +302,7 @@ class BotApp(hikari.GatewayBot):
         Returns:
             :obj:`asyncio.Task`: Created task object.
         """
-        task: asyncio.Task[None] = asyncio.create_task(coro, name=name) # type: ignore [arg-type]
+        task: asyncio.Task[None] = asyncio.create_task(coro, name=name)  # type: ignore [arg-type]
         self._running_tasks.append(task)
         task.add_done_callback(lambda task_: self._running_tasks.remove(task_))
         return task

--- a/lightbulb/app.py
+++ b/lightbulb/app.py
@@ -302,7 +302,7 @@ class BotApp(hikari.GatewayBot):
         Returns:
             :obj:`asyncio.Task`: Created task object.
         """
-        task = asyncio.create_task(coro, name=name)  # type: ignore [var-annotated, arg-type]
+        task: asyncio.Task[None] = asyncio.create_task(coro, name=name) # type: ignore [arg-type]
         self._running_tasks.append(task)
         task.add_done_callback(lambda task_: self._running_tasks.remove(task_))
         return task

--- a/lightbulb/app.py
+++ b/lightbulb/app.py
@@ -302,7 +302,7 @@ class BotApp(hikari.GatewayBot):
         Returns:
             :obj:`asyncio.Task`: Created task object.
         """
-        task = asyncio.create_task(coro, name=name)
+        task = asyncio.create_task(coro, name=name)  # type: ignore [var-annotated, arg-type]
         self._running_tasks.append(task)
         task.add_done_callback(lambda task_: self._running_tasks.remove(task_))
         return task

--- a/lightbulb/checks.py
+++ b/lightbulb/checks.py
@@ -244,12 +244,9 @@ def _has_roles(
 def _has_guild_permissions(context: context_.base.Context, *, perms: hikari.Permissions) -> bool:
     _guild_only(context)
 
-    channel, guild = context.get_channel(), context.get_guild()
-    if channel is None or guild is None:
+    channel = context.get_channel()
+    if channel is None:
         raise errors.InsufficientCache("Some objects required for this check could not be resolved from the cache")
-
-    if guild.owner_id == context.author.id:
-        return True
 
     assert context.member is not None and isinstance(channel, hikari.GuildChannel)
     missing_perms = ~permissions.permissions_in(channel, context.member) & perms
@@ -297,9 +294,6 @@ def _bot_has_guild_permissions(context: context_.base.Context, *, perms: hikari.
     member = guild.get_my_member()
     if member is None:
         raise errors.InsufficientCache("Some objects required for this check could not be resolved from the cache")
-
-    if guild.owner_id == member.id:
-        return True
 
     assert isinstance(channel, hikari.GuildChannel)
     missing_perms = ~permissions.permissions_in(channel, member) & perms

--- a/lightbulb/utils/permissions.py
+++ b/lightbulb/utils/permissions.py
@@ -40,7 +40,9 @@ def permissions_for(member: hikari.Member) -> hikari.Permissions:
     for role in member.get_roles():
         permissions |= role.permissions
 
-    if hikari.Permissions.ADMINISTRATOR in permissions or member.id == member.get_guild().owner_id:
+    guild = member.get_guild()
+
+    if hikari.Permissions.ADMINISTRATOR in permissions or guild and member.id == guild.owner_id:
         return hikari.Permissions.all_permissions()
 
     return permissions
@@ -65,7 +67,9 @@ def permissions_in(
     if include_guild_permissions:
         allowed_perms |= permissions_for(member)
 
-    if hikari.Permissions.ADMINISTRATOR in allowed_perms or member.id == member.get_guild().owner_id:
+    guild = member.get_guild()
+
+    if hikari.Permissions.ADMINISTRATOR in allowed_perms or guild and member.id == guild.owner_id:
         return hikari.Permissions.all_permissions()
 
     overwrites = channel.permission_overwrites

--- a/lightbulb/utils/permissions.py
+++ b/lightbulb/utils/permissions.py
@@ -40,7 +40,7 @@ def permissions_for(member: hikari.Member) -> hikari.Permissions:
     for role in member.get_roles():
         permissions |= role.permissions
 
-    if hikari.Permissions.ADMINISTRATOR in permissions:
+    if hikari.Permissions.ADMINISTRATOR in permissions or member.id == member.get_guild().owner_id:
         return hikari.Permissions.all_permissions()
 
     return permissions
@@ -65,7 +65,7 @@ def permissions_in(
     if include_guild_permissions:
         allowed_perms |= permissions_for(member)
 
-    if hikari.Permissions.ADMINISTRATOR in allowed_perms:
+    if hikari.Permissions.ADMINISTRATOR in allowed_perms or member.id == member.get_guild().owner_id:
         return hikari.Permissions.all_permissions()
 
     overwrites = channel.permission_overwrites


### PR DESCRIPTION
### Summary
Make `lightbulb.utils.permissions_for()` and `lightbulb.utils.permissions_in()` account for the passed member being the owner of the guild and return all permissions accordingly.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
