### PR TITLE
Allow a user to iterate through ctx.options

### DIFF
--- a/lightbulb/context/base.py
+++ b/lightbulb/context/base.py
@@ -59,7 +59,7 @@ class OptionsProxy:
         pairs.
 
         Returns:
-            :obj:`dict_items[:obj:`str`, Any]`: The options items. This
+            ItemsView[:obj:`str`, Any]: The options items. This
                 is functionally similar to a list of tuples, where for
                 each tuple, the key is the option name, and the value is
                 the option value.

--- a/lightbulb/context/base.py
+++ b/lightbulb/context/base.py
@@ -32,8 +32,6 @@ if t.TYPE_CHECKING:
     from lightbulb import app as app_
     from lightbulb import commands
 
-    dict_items = type({}.items())
-
 
 class OptionsProxy:
     """
@@ -55,7 +53,7 @@ class OptionsProxy:
     def __getitem__(self, item: str) -> t.Any:
         return self._options.get(item)
 
-    def items(self) -> dict_items[str, t.Any]:
+    def items(self) -> t.ItemsView[str, t.Any]:
         """
         Iterates through the options and returns a series of key:value
         pairs.

--- a/lightbulb/context/base.py
+++ b/lightbulb/context/base.py
@@ -32,6 +32,8 @@ if t.TYPE_CHECKING:
     from lightbulb import app as app_
     from lightbulb import commands
 
+    dict_items = type({}.items())
+
 
 class OptionsProxy:
     """
@@ -42,6 +44,8 @@ class OptionsProxy:
         options (Dict[:obj:`str`, Any]): Options to act as a proxy for.
     """
 
+    __slots__ = ("_options",)
+
     def __init__(self, options: t.Dict[str, t.Any]) -> None:
         self._options = options
 
@@ -50,6 +54,19 @@ class OptionsProxy:
 
     def __getitem__(self, item: str) -> t.Any:
         return self._options.get(item)
+
+    def items(self) -> dict_items[str, t.Any]:
+        """
+        Iterates through the options and returns a series of key:value
+        pairs.
+
+        Returns:
+            :obj:`dict_items[:obj:`str`, Any]`: The options items. This
+                is functionally similar to a list of tuples, where for
+                each tuple, the key is the option name, and the value is
+                the option value.
+        """
+        return self._options.items()
 
 
 class ResponseProxy:


### PR DESCRIPTION
### Summary
- Adds `OptionsProxy.items()`, which functions identically to `dict.items()`, allowing users to iterate through options should they wish to
- Fixes an issue in the `format_fix` nox session that meant it always failed

### Checklist
- [x] I have run `nox` and all the pipelines have passed.

### Related issues
None
