### PR TITLE
Swap order of plugins and extensions guide

### DIFF
--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -19,5 +19,5 @@ contact thomm.o#8637 on discord.
    guides/commands
    guides/custom-help
    guides/error-handling
-   guides/extensions
    guides/plugins
+   guides/extensions


### PR DESCRIPTION
### Summary
The rationale behind this PR is that most new users following guides are likely to do so in a linear fashion, continuing from one page to the other, and the extensions page basically already assumes that one knows what a plugin is and how to use it, but this is only explained in the proceeding page. This may alleviate some confusion as to how these two concepts fit together.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
