### PR TITLE
Add support for Python 3.11

### DIFF
--- a/docs/source/changelogs/v2-changelog.rst
+++ b/docs/source/changelogs/v2-changelog.rst
@@ -6,6 +6,11 @@ Below are all the changelogs for the stable versions of hikari-lightbulb (versio
 
 ----
 
+Version 2.3.0
+=============
+
+- Add support for Python 3.11.
+
 Version 2.2.4
 =============
 

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     zip_safe=False,
     install_requires=parse_requirements_file("requirements.txt"),
     extras_require={"crontrigger": parse_requirements_file("crontrigger_requirements.txt")},
-    python_requires=">=3.8.0,<=3.11",
+    python_requires=">=3.8.0,<3.12",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: AsyncIO",

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     zip_safe=False,
     install_requires=parse_requirements_file("requirements.txt"),
     extras_require={"crontrigger": parse_requirements_file("crontrigger_requirements.txt")},
-    python_requires=">=3.8.0,<3.11",
+    python_requires=">=3.8.0,<=3.11",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: AsyncIO",
@@ -80,6 +80,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Software Development :: Libraries",


### PR DESCRIPTION
### Summary
Add support for Python 3.11 (which was released yesterday).

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
