### PR TITLE
Fix deferral of slash sub-commands

### DIFF
--- a/docs/source/changelogs/v2-changelog.rst
+++ b/docs/source/changelogs/v2-changelog.rst
@@ -13,6 +13,8 @@ Version 2.3.2
 
 - Module ``lightbulb.utils.parser`` has been moved up a level to ``lightbulb.parser``.
 
+- ``OptionsProxy`` will now raise an :obj:`AttributeError` when trying to access an option that does not exist.
+
 **Other Changes**
 
 - Slash commands now have full custom converter support.
@@ -22,6 +24,8 @@ Version 2.3.2
 - Fix :obj:`~lightbulb.commands.base.ApplicationCommand.nsfw` not applying correctly for global commands.
 
 - Implement ``min_length`` and ``max_length`` for command options.
+
+- Fix deferral of slash subcommands not working as intended.
 
 Version 2.3.1
 =============

--- a/lightbulb/commands/slash.py
+++ b/lightbulb/commands/slash.py
@@ -77,15 +77,14 @@ class SlashGroupMixin(abc.ABC):
         assert isinstance(context, context_.slash.SlashContext)
         cmd_option = context._raw_options[0]
         context._raw_options = cmd_option.options or []
-        subcommand = self._subcommands[cmd_option.name]
         # Replace the invoked command prematurely so that _parse_options uses the correct command options
-        context._invoked = subcommand
-        # Re-parse the options for the subcommand
+        context._invoked = self._subcommands[cmd_option.name]
+        # Reparse the options for the subcommand
         context._parse_options(cmd_option.options)
         # Ensure we call _maybe_defer
         await context._maybe_defer()
         # Invoke the subcommand
-        await subcommand.invoke(context)
+        await context._invoked.invoke(context)
 
     def get_subcommand(self, name: str) -> t.Optional[t.Union[SlashSubGroup, SlashSubCommand]]:
         """Get the group's subcommand with the given name."""

--- a/lightbulb/commands/slash.py
+++ b/lightbulb/commands/slash.py
@@ -77,12 +77,15 @@ class SlashGroupMixin(abc.ABC):
         assert isinstance(context, context_.slash.SlashContext)
         cmd_option = context._raw_options[0]
         context._raw_options = cmd_option.options or []
+        subcommand = self._subcommands[cmd_option.name]
         # Replace the invoked command prematurely so that _parse_options uses the correct command options
-        context._invoked = self._subcommands[cmd_option.name]
+        context._invoked = subcommand
         # Re-parse the options for the subcommand
         context._parse_options(cmd_option.options)
+        # Ensure we call _maybe_defer
+        await context._maybe_defer()
         # Invoke the subcommand
-        await self._subcommands[cmd_option.name].invoke(context)
+        await subcommand.invoke(context)
 
     def get_subcommand(self, name: str) -> t.Optional[t.Union[SlashSubGroup, SlashSubCommand]]:
         """Get the group's subcommand with the given name."""

--- a/lightbulb/context/base.py
+++ b/lightbulb/context/base.py
@@ -455,7 +455,10 @@ class ApplicationContext(Context, abc.ABC):
         self._command = command
 
     async def _maybe_defer(self) -> None:
-        if (self._invoked or self._command).auto_defer and not self._deferred:
+        if self._deferred:
+            return
+
+        if (self._invoked or self._command).auto_defer:
             await self.respond(hikari.ResponseType.DEFERRED_MESSAGE_CREATE)
 
     @property

--- a/lightbulb/context/base.py
+++ b/lightbulb/context/base.py
@@ -50,10 +50,16 @@ class OptionsProxy:
         self._options = options
 
     def __getattr__(self, item: str) -> t.Any:
-        return self._options.get(item)
+        try:
+            return self._options[item]
+        except KeyError:
+            raise AttributeError(f"There is no option called '{item}'") from None
 
     def __getitem__(self, item: str) -> t.Any:
-        return self._options.get(item)
+        try:
+            return self._options[item]
+        except KeyError:
+            raise AttributeError(f"There is no option called '{item}'") from None
 
     def items(self) -> t.ItemsView[str, t.Any]:
         """
@@ -449,7 +455,7 @@ class ApplicationContext(Context, abc.ABC):
         self._command = command
 
     async def _maybe_defer(self) -> None:
-        if (self._invoked or self._command).auto_defer:
+        if (self._invoked or self._command).auto_defer and not self._deferred:
             await self.respond(hikari.ResponseType.DEFERRED_MESSAGE_CREATE)
 
     @property

--- a/lightbulb/context/prefix.py
+++ b/lightbulb/context/prefix.py
@@ -66,7 +66,7 @@ class PrefixContext(base.Context):
         self._parser: parser.BaseParser
 
     async def _maybe_defer(self) -> None:
-        if self._command is not None and (self._invoked or self._command).auto_defer:
+        if self._command is not None and (self._invoked or self._command).auto_defer and not self._deferred:
             await self.app.rest.trigger_typing(self.channel_id)
             self._deferred = True
 

--- a/lightbulb/context/prefix.py
+++ b/lightbulb/context/prefix.py
@@ -66,7 +66,10 @@ class PrefixContext(base.Context):
         self._parser: parser.BaseParser
 
     async def _maybe_defer(self) -> None:
-        if self._command is not None and (self._invoked or self._command).auto_defer and not self._deferred:
+        if self._deferred:
+            return
+
+        if self._command is not None and (self._invoked or self._command).auto_defer:
             await self.app.rest.trigger_typing(self.channel_id)
             self._deferred = True
 


### PR DESCRIPTION
### Summary
Fix the deferral of slash sub-commands, which also had the side effect of no longer converting `str` type arguments, as it is done in `_maybe_defer`.

Additionally, to prevent future confusion if something like this ever happens again, `OptionsProxy` will error if you try to access an invalid option.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
