### PR TITLE
Replace CommandChoice & hikari.impl.bot

### DIFF
--- a/lightbulb/app.py
+++ b/lightbulb/app.py
@@ -145,7 +145,7 @@ def _default_get_prefix(_: BotApp, __: hikari.Message, *, prefixes: t.Sequence[s
 
 class BotApp(hikari.GatewayBot):
     """
-    A subclassed implementation of the :obj:`~hikari.impl.bot.GatewayBot` class containing a command
+    A subclassed implementation of the :obj:`~hikari.impl.gateway_bot.GatewayBot` class containing a command
     handler. This should be instantiated instead of the superclass if you wish to use the command
     handler implementation provided.
 
@@ -168,7 +168,7 @@ class BotApp(hikari.GatewayBot):
             find an implementation for when the bot starts. Defaults to ``True``.
         case_insensitive_prefix_commands (:obj:`bool`): Whether or not prefix command names should be case-insensitive.
             Defaults to ``False``.
-        **kwargs (Any): Additional keyword arguments passed to the constructor of the :obj:`~hikari.impl.bot.GatewayBot`
+        **kwargs (Any): Additional keyword arguments passed to the constructor of the :obj:`~hikari.impl.gateway_bot.GatewayBot`
             class.
     """
 
@@ -1262,13 +1262,15 @@ class BotApp(hikari.GatewayBot):
             await event.interaction.create_response([])
             return
 
-        def convert_response_value(val: t.Union[str, int, float, hikari.CommandChoice]) -> hikari.CommandChoice:
+        def convert_response_value(
+            val: t.Union[str, int, float, hikari.impl.AutocompleteChoiceBuilder]
+        ) -> hikari.impl.AutocompleteChoiceBuilder:
             if isinstance(val, (str, int, float)):
-                return hikari.CommandChoice(name=str(val), value=val)
+                return hikari.impl.AutocompleteChoiceBuilder(name=str(val), value=val)
             return val
 
-        resp_to_send: t.List[hikari.CommandChoice] = []
-        if isinstance(response, (str, int, float, hikari.CommandChoice)):
+        resp_to_send: t.List[hikari.impl.AutocompleteChoiceBuilder] = []
+        if isinstance(response, (str, int, float, hikari.impl.AutocompleteChoiceBuilder)):
             resp_to_send.append(convert_response_value(response))
         elif isinstance(response, collections.abc.Sequence):
             for item in response:

--- a/lightbulb/app.py
+++ b/lightbulb/app.py
@@ -1262,15 +1262,27 @@ class BotApp(hikari.GatewayBot):
             await event.interaction.create_response([])
             return
 
+        warned = False
+
         def convert_response_value(
-            val: t.Union[str, int, float, hikari.impl.AutocompleteChoiceBuilder]
-        ) -> hikari.impl.AutocompleteChoiceBuilder:
+            val: t.Union[str, int, float, hikari.api.AutocompleteChoiceBuilder]
+        ) -> hikari.api.AutocompleteChoiceBuilder:
             if isinstance(val, (str, int, float)):
                 return hikari.impl.AutocompleteChoiceBuilder(name=str(val), value=val)
+            if isinstance(val, hikari.CommandChoice):
+                nonlocal warned
+                if not warned:
+                    _LOGGER.warning(
+                        "DeprecationWarning: Passing CommandChoice is deprecated and will be removed in `2.0.0.dev119`. Use AutocompleteChoiceBuilder instead"
+                    )
+                    warned = True
+
+                return hikari.impl.AutocompleteChoiceBuilder(name=val.name, value=val.value)
+
             return val
 
-        resp_to_send: t.List[hikari.impl.AutocompleteChoiceBuilder] = []
-        if isinstance(response, (str, int, float, hikari.impl.AutocompleteChoiceBuilder)):
+        resp_to_send: t.List[hikari.api.AutocompleteChoiceBuilder] = []
+        if isinstance(response, (str, int, float, hikari.api.AutocompleteChoiceBuilder)):
             resp_to_send.append(convert_response_value(response))
         elif isinstance(response, collections.abc.Sequence):
             for item in response:

--- a/lightbulb/commands/base.py
+++ b/lightbulb/commands/base.py
@@ -53,8 +53,8 @@ AutocompleteCallbackT = t.TypeVar(
             t.Any,
             t.Union[
                 _AutocompleteableOptionT,
-                hikari.impl.AutocompleteChoiceBuilder,
-                t.Sequence[t.Union[_AutocompleteableOptionT, hikari.impl.AutocompleteChoiceBuilder]],
+                hikari.api.AutocompleteChoiceBuilder,
+                t.Sequence[t.Union[_AutocompleteableOptionT, hikari.api.AutocompleteChoiceBuilder]],
             ],
         ],
     ],
@@ -374,8 +374,8 @@ class CommandLike:
                 t.Any,
                 t.Union[
                     _AutocompleteableOptionT,
-                    hikari.impl.AutocompleteChoiceBuilder,
-                    t.Sequence[t.Union[_AutocompleteableOptionT, hikari.impl.AutocompleteChoiceBuilder]],
+                    hikari.api.AutocompleteChoiceBuilder,
+                    t.Sequence[t.Union[_AutocompleteableOptionT, hikari.api.AutocompleteChoiceBuilder]],
                 ],
             ],
         ],
@@ -522,7 +522,7 @@ class CommandLike:
                 @foo.autocomplete("foo")  # Name of the option you want to autocomplete
                 async def foo_autocomplete(
                     opt: hikari.AutocompleteInteractionOption, inter: hikari.AutocompleteInteraction
-                ) -> Union[str, Sequence[str], hikari.impl.AutocompleteChoiceBuilder, Sequence[hikari.impl.AutocompleteChoiceBuilder]]:
+                ) -> Union[str, Sequence[str], hikari.api.AutocompleteChoiceBuilder, Sequence[hikari.api.AutocompleteChoiceBuilder]]:
                     ...
         """
 

--- a/lightbulb/commands/base.py
+++ b/lightbulb/commands/base.py
@@ -53,8 +53,8 @@ AutocompleteCallbackT = t.TypeVar(
             t.Any,
             t.Union[
                 _AutocompleteableOptionT,
-                hikari.CommandChoice,
-                t.Sequence[t.Union[_AutocompleteableOptionT, hikari.CommandChoice]],
+                hikari.impl.AutocompleteChoiceBuilder,
+                t.Sequence[t.Union[_AutocompleteableOptionT, hikari.impl.AutocompleteChoiceBuilder]],
             ],
         ],
     ],
@@ -161,13 +161,13 @@ class OptionLike:
     min_value: t.Optional[t.Union[float, int]] = None
     """
     The minimum value permitted for this option (inclusive). The option must be ``INTEGER`` or ``FLOAT`` to use this.
-    
+
     .. versionadded:: 2.1.3
     """
     max_value: t.Optional[t.Union[float, int]] = None
     """
     The maximum value permitted for this option (inclusive). The option must be ``INTEGER`` or ``FLOAT`` to use this.
-    
+
     .. versionadded:: 2.1.3
     """
     min_length: t.Optional[int] = None
@@ -317,52 +317,52 @@ class CommandLike:
     pass_options: bool = False
     """
     Whether or not the command will have its options passed as keyword arguments when invoked.
-    
+
     .. versionadded:: 2.2.1
     """
     max_concurrency: t.Optional[t.Tuple[int, t.Type[buckets.Bucket]]] = None
     """
     The max concurrency rule for the command.
-    
+
     .. versionadded:: 2.2.1
     """
     app_command_default_member_permissions: t.Optional[hikari.Permissions] = None
     """
     The default member permissions for this command, if an application command.
-    
+
     .. versionadded:: 2.2.3
     """
     app_command_dm_enabled: bool = True
     """
     Whether this command will be enabled in DMs, if an application command.
-    
+
     .. versionadded:: 2.2.3
     """
     app_command_bypass_author_permission_checks: bool = False
     """
     Whether invocations of this command will bypass author permission checks, if an application command.
-    
+
     .. versionadded:: 2.2.3
     """
     name_localizations: t.Mapping[t.Union[hikari.Locale, str], str] = dataclasses.field(default_factory=dict)
     """
     A mapping of locale to name localizations for this command
-    
+
     .. versionadded:: 2.3.0
     """
     description_localizations: t.Mapping[t.Union[hikari.Locale, str], str] = dataclasses.field(default_factory=dict)
     """
     A mapping of locale to description localizations for this command
-    
+
     .. versionadded:: 2.3.0
     """
     nsfw: bool = False
     """
     Whether the command should only be enabled in NSFW channels.
-    
+
     For prefix commands, this will add an NSFW-channel only check to the command automatically.
     For slash commands, this will behave as specified in the Discord documentation.
-    
+
     .. versionadded:: 2.3.1
     """
     _autocomplete_callbacks: t.Dict[
@@ -374,8 +374,8 @@ class CommandLike:
                 t.Any,
                 t.Union[
                     _AutocompleteableOptionT,
-                    hikari.CommandChoice,
-                    t.Sequence[t.Union[_AutocompleteableOptionT, hikari.CommandChoice]],
+                    hikari.impl.AutocompleteChoiceBuilder,
+                    t.Sequence[t.Union[_AutocompleteableOptionT, hikari.impl.AutocompleteChoiceBuilder]],
                 ],
             ],
         ],
@@ -522,7 +522,7 @@ class CommandLike:
                 @foo.autocomplete("foo")  # Name of the option you want to autocomplete
                 async def foo_autocomplete(
                     opt: hikari.AutocompleteInteractionOption, inter: hikari.AutocompleteInteraction
-                ) -> Union[str, Sequence[str], hikari.CommandChoice, Sequence[hikari.CommandChoice]]:
+                ) -> Union[str, Sequence[str], hikari.impl.AutocompleteChoiceBuilder, Sequence[hikari.impl.AutocompleteChoiceBuilder]]:
                     ...
         """
 

--- a/lightbulb/decorators.py
+++ b/lightbulb/decorators.py
@@ -52,7 +52,7 @@ AutocompleteCallbackT = t.Callable[
         t.Any,
         t.Any,
         t.Union[
-            str, hikari.impl.AutocompleteChoiceBuilder, t.Sequence[t.Union[str, hikari.impl.AutocompleteChoiceBuilder]]
+            str, hikari.api.AutocompleteChoiceBuilder, t.Sequence[t.Union[str, hikari.api.AutocompleteChoiceBuilder]]
         ],
     ],
 ]

--- a/lightbulb/decorators.py
+++ b/lightbulb/decorators.py
@@ -48,7 +48,13 @@ T = t.TypeVar("T")
 CommandCallbackT = t.TypeVar("CommandCallbackT", bound=t.Callable[..., t.Coroutine[t.Any, t.Any, None]])
 AutocompleteCallbackT = t.Callable[
     [hikari.CommandInteractionOption, hikari.AutocompleteInteraction],
-    t.Coroutine[t.Any, t.Any, t.Union[str, hikari.CommandChoice, t.Sequence[t.Union[str, hikari.CommandChoice]]]],
+    t.Coroutine[
+        t.Any,
+        t.Any,
+        t.Union[
+            str, hikari.impl.AutocompleteChoiceBuilder, t.Sequence[t.Union[str, hikari.impl.AutocompleteChoiceBuilder]]
+        ],
+    ],
 ]
 
 


### PR DESCRIPTION
### Summary
- Replaced deprecated hikari.CommandChoice with hikari.impl.AutocompleteChoiceBuilder for autocomplete
- Replaced hikari.impl.bot.GatewayBot with hikari.impl.gateway_bot.GatewayBot in docstring

### Checklist
- [x] I have run `nox` and all the pipelines have passed.

### Related issues
