### PR TITLE
Add bucket attribute to MaxConcurrencyLimitReached

### DIFF
--- a/docs/source/changelogs/v2-changelog.rst
+++ b/docs/source/changelogs/v2-changelog.rst
@@ -6,6 +6,13 @@ Below are all the changelogs for the stable versions of hikari-lightbulb (versio
 
 ----
 
+Version 2.3.3
+=============
+
+**Other Changes**
+
+- ``bucket`` attribute has been added to the :obj:`~lightbulb.errors.MaxConcurrencyLimitReached` class.
+
 Version 2.3.2
 =============
 

--- a/lightbulb/commands/base.py
+++ b/lightbulb/commands/base.py
@@ -161,13 +161,13 @@ class OptionLike:
     min_value: t.Optional[t.Union[float, int]] = None
     """
     The minimum value permitted for this option (inclusive). The option must be ``INTEGER`` or ``FLOAT`` to use this.
-    
+
     .. versionadded:: 2.1.3
     """
     max_value: t.Optional[t.Union[float, int]] = None
     """
     The maximum value permitted for this option (inclusive). The option must be ``INTEGER`` or ``FLOAT`` to use this.
-    
+
     .. versionadded:: 2.1.3
     """
     min_length: t.Optional[int] = None
@@ -317,52 +317,52 @@ class CommandLike:
     pass_options: bool = False
     """
     Whether or not the command will have its options passed as keyword arguments when invoked.
-    
+
     .. versionadded:: 2.2.1
     """
     max_concurrency: t.Optional[t.Tuple[int, t.Type[buckets.Bucket]]] = None
     """
     The max concurrency rule for the command.
-    
+
     .. versionadded:: 2.2.1
     """
     app_command_default_member_permissions: t.Optional[hikari.Permissions] = None
     """
     The default member permissions for this command, if an application command.
-    
+
     .. versionadded:: 2.2.3
     """
     app_command_dm_enabled: bool = True
     """
     Whether this command will be enabled in DMs, if an application command.
-    
+
     .. versionadded:: 2.2.3
     """
     app_command_bypass_author_permission_checks: bool = False
     """
     Whether invocations of this command will bypass author permission checks, if an application command.
-    
+
     .. versionadded:: 2.2.3
     """
     name_localizations: t.Mapping[t.Union[hikari.Locale, str], str] = dataclasses.field(default_factory=dict)
     """
     A mapping of locale to name localizations for this command
-    
+
     .. versionadded:: 2.3.0
     """
     description_localizations: t.Mapping[t.Union[hikari.Locale, str], str] = dataclasses.field(default_factory=dict)
     """
     A mapping of locale to description localizations for this command
-    
+
     .. versionadded:: 2.3.0
     """
     nsfw: bool = False
     """
     Whether the command should only be enabled in NSFW channels.
-    
+
     For prefix commands, this will add an NSFW-channel only check to the command automatically.
     For slash commands, this will behave as specified in the Discord documentation.
-    
+
     .. versionadded:: 2.3.1
     """
     _autocomplete_callbacks: t.Dict[
@@ -772,7 +772,8 @@ class Command(abc.ABC):
         if self._max_concurrency_semaphores[bucket_hash].locked():
             assert context.invoked is not None
             raise errors.MaxConcurrencyLimitReached(
-                f"Maximum concurrency limit for command '{context.invoked.qualname}' exceeded"
+                f"Maximum concurrency limit for command '{context.invoked.qualname}' exceeded",
+                bucket=self.max_concurrency[1],
             )
         await self._max_concurrency_semaphores[bucket_hash].acquire()
 

--- a/lightbulb/errors.py
+++ b/lightbulb/errors.py
@@ -55,6 +55,7 @@ import warnings
 import hikari
 
 if t.TYPE_CHECKING:
+    from lightbulb import buckets
     from lightbulb import commands
 
 
@@ -160,7 +161,7 @@ class ConverterFailure(LightbulbError):
         self.raw_value: str = raw
         """
         The value that could not be converted.
-        
+
         .. versionadded:: 2.2.1
         """
 
@@ -196,6 +197,13 @@ class MaxConcurrencyLimitReached(LightbulbError):
     Error raised when the maximum number of allowed concurrent invocations for a command
     has been exceeded.
     """
+
+    __slots__ = ("bucket",)
+
+    def __init__(self, *args: t.Any, bucket: t.Type[buckets.Bucket]) -> None:
+        super().__init__(*args)
+        self.bucket = bucket
+        """The bucket type that triggered the max concurrency limit."""
 
 
 class CheckFailure(LightbulbError):

--- a/lightbulb/errors.py
+++ b/lightbulb/errors.py
@@ -203,7 +203,11 @@ class MaxConcurrencyLimitReached(LightbulbError):
     def __init__(self, *args: t.Any, bucket: t.Type[buckets.Bucket]) -> None:
         super().__init__(*args)
         self.bucket = bucket
-        """The bucket type that triggered the max concurrency limit."""
+        """
+        The bucket type that triggered the max concurrency limit.
+
+        .. versionadded:: 2.3.3
+        """
 
 
 class CheckFailure(LightbulbError):


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

This PR adds a `bucket` attribute of type `Type[Bucket]` to `MaxConcurrencyLimitReached`.

## Example usage

```python
events = lightbulb.Plugin("events")

@events.listener(lightbulb.CommandErrorEvent)
async def on_command_error(event: lightbulb.CommandErrorEvent) -> None:
    e = event.exception

    if isinstance(e, lightbulb.MaxConcurrencyLimitReached):
        if e.bucket is lightbulb.UserBucket:
            ...
        elif e.bucket is lightbulb.GlobalBucket:
            ...
```

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->

None