### PR TITLE
Fix custom option converter not being initialized

### DIFF
--- a/lightbulb/context/slash.py
+++ b/lightbulb/context/slash.py
@@ -62,7 +62,7 @@ class SlashContext(base.ApplicationContext):
         if opt_type in CONVERTER_TYPE_MAPPING:
             self._options[name] = await CONVERTER_TYPE_MAPPING[cmd.options[name].arg_type](self).convert(value)
         elif inspect.isclass(opt_type) and issubclass(cmd.options[name].arg_type, BaseConverter):
-            self._options[name] = await opt_type.convert(value)
+            self._options[name] = await opt_type(self).convert(value)
         elif callable(opt_type):
             temp: t.Any = opt_type(value)
             if inspect.iscoroutine(temp):


### PR DESCRIPTION
### Summary
```py
class CustomConverter(BaseConverter[str]):
    __slots__ = ()

    async def convert(self, arg: str) -> str:
        ...


@lightbulb.option("start", "auction start time.", type=CustomConverter)
```
If a custom option type is set it gets initialized with the context when using prefix commands, but doesn't when using slash commands.
This pull request fixes it.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
