### PR TITLE
Fix localization options not being passed to subcommands or options

### DIFF
--- a/lightbulb/commands/slash.py
+++ b/lightbulb/commands/slash.py
@@ -120,6 +120,8 @@ class SlashCommand(base.ApplicationCommand):
             "name": self.name,
             "description": self.description,
             "options": [o.as_application_command_option() for o in sorted_opts],
+            "name_localizations": self.name_localizations,
+            "description_localizations": self.description_localizations
         }
 
     def _validate_attributes(self) -> None:
@@ -153,6 +155,8 @@ class SlashSubCommand(SlashCommand, base.SubCommandTrait):
             description=self.description,
             is_required=False,
             options=[o.as_application_command_option() for o in sorted_opts],
+            name_localizations=self.name_localizations,
+            description_localizations=self.description_localizations
         )
 
 
@@ -187,6 +191,8 @@ class SlashSubGroup(SlashCommand, SlashGroupMixin, base.SubCommandTrait):
             description=self.description,
             is_required=False,
             options=[c.as_option() for c in self._subcommands.values()],
+            name_localizations=self.name_localizations,
+            description_localizations=self.description_localizations
         )
 
     async def invoke(self, context: context_.base.Context, **_: t.Any) -> None:
@@ -228,6 +234,8 @@ class SlashCommandGroup(SlashCommand, SlashGroupMixin):
             "name": self.name,
             "description": self.description,
             "options": [c.as_option() for c in self._subcommands.values()],
+            "name_localizations": self.name_localizations,
+            "description_localizations": self.description_localizations
         }
 
     def _validate_attributes(self) -> None:

--- a/lightbulb/commands/slash.py
+++ b/lightbulb/commands/slash.py
@@ -121,7 +121,7 @@ class SlashCommand(base.ApplicationCommand):
             "description": self.description,
             "options": [o.as_application_command_option() for o in sorted_opts],
             "name_localizations": self.name_localizations,
-            "description_localizations": self.description_localizations
+            "description_localizations": self.description_localizations,
         }
 
     def _validate_attributes(self) -> None:
@@ -156,7 +156,7 @@ class SlashSubCommand(SlashCommand, base.SubCommandTrait):
             is_required=False,
             options=[o.as_application_command_option() for o in sorted_opts],
             name_localizations=self.name_localizations,
-            description_localizations=self.description_localizations
+            description_localizations=self.description_localizations,
         )
 
 
@@ -192,7 +192,7 @@ class SlashSubGroup(SlashCommand, SlashGroupMixin, base.SubCommandTrait):
             is_required=False,
             options=[c.as_option() for c in self._subcommands.values()],
             name_localizations=self.name_localizations,
-            description_localizations=self.description_localizations
+            description_localizations=self.description_localizations,
         )
 
     async def invoke(self, context: context_.base.Context, **_: t.Any) -> None:
@@ -235,7 +235,7 @@ class SlashCommandGroup(SlashCommand, SlashGroupMixin):
             "description": self.description,
             "options": [c.as_option() for c in self._subcommands.values()],
             "name_localizations": self.name_localizations,
-            "description_localizations": self.description_localizations
+            "description_localizations": self.description_localizations,
         }
 
     def _validate_attributes(self) -> None:

--- a/lightbulb/internal.py
+++ b/lightbulb/internal.py
@@ -140,7 +140,8 @@ def _create_builder_from_command(
         if cmd.app_command_default_member_permissions is not None:
             bld.set_default_member_permissions(cmd.app_command_default_member_permissions)
         bld.set_name_localizations(cmd.name_localizations)
-        bld.set_description_localizations(cmd.description_localizations)
+        if isinstance(bld, hikari.api.SlashCommandBuilder):
+            bld.set_description_localizations(cmd.description_localizations)
         bld.set_is_dm_enabled(cmd.app_command_dm_enabled)
         bld.set_is_nsfw(cmd.nsfw)
 

--- a/lightbulb/internal.py
+++ b/lightbulb/internal.py
@@ -125,12 +125,13 @@ def _create_builder_from_command(
         bld.set_default_member_permissions(cmd.default_member_permissions)
         bld.set_is_dm_enabled(cmd.is_dm_enabled)
         bld.set_is_nsfw(cmd.is_nsfw)
-
+        bld.set_name_localizations(cmd.name_localizations)
         bld.set_id(cmd.id)
     else:
         create_kwargs = cmd.as_create_kwargs()
         if "description" in create_kwargs:
             bld = app.rest.slash_command_builder(create_kwargs["name"], description=create_kwargs["description"])
+            bld.set_description_localizations(cmd.description_localizations)
             for opt in create_kwargs.get("options", []):
                 bld.add_option(opt)
         else:
@@ -138,7 +139,10 @@ def _create_builder_from_command(
 
         if cmd.app_command_default_member_permissions is not None:
             bld.set_default_member_permissions(cmd.app_command_default_member_permissions)
+        bld.set_name_localizations(cmd.name_localizations)
+        bld.set_description_localizations(cmd.description_localizations)
         bld.set_is_dm_enabled(cmd.app_command_dm_enabled)
+        bld.set_name_localizations(cmd.name_localizations)
         bld.set_is_nsfw(cmd.nsfw)
 
     return bld

--- a/lightbulb/internal.py
+++ b/lightbulb/internal.py
@@ -142,7 +142,6 @@ def _create_builder_from_command(
         bld.set_name_localizations(cmd.name_localizations)
         bld.set_description_localizations(cmd.description_localizations)
         bld.set_is_dm_enabled(cmd.app_command_dm_enabled)
-        bld.set_name_localizations(cmd.name_localizations)
         bld.set_is_nsfw(cmd.nsfw)
 
     return bld


### PR DESCRIPTION
### Summary
This PR fixes name_localizations and description_localizations not being passed to slash subcommands, slash groups, and slash subgroups, as well as slash command options.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
No related issues, but bug was first mentioned in #lightbulb in the hikari server here: https://discord.com/channels/574921006817476608/727982024660615198/1107738439413141654
