### PR TITLE
Minor improvements

### DIFF
--- a/lightbulb/checks.py
+++ b/lightbulb/checks.py
@@ -59,6 +59,8 @@ _CallbackT = t.Union[
 
 
 class _ExclusiveCheck:
+    __slots__ = ("_checks",)
+
     def __init__(self, *checks: "Check") -> None:
         self._checks = list(checks)
 

--- a/lightbulb/commands/base.py
+++ b/lightbulb/commands/base.py
@@ -22,13 +22,13 @@ __all__ = ["OptionModifier", "OptionLike", "CommandLike", "Command", "Applicatio
 import abc
 import asyncio
 import collections
-import dataclasses
 import datetime
 import enum
 import inspect
 import re
 import typing as t
 
+import attrs
 import hikari
 
 from lightbulb import errors
@@ -103,8 +103,6 @@ class _HasRecreateSubcommands(t.Protocol):
 
 
 class _SubcommandListProxy(collections.UserList):  # type: ignore
-    __slots__ = ("parents",)
-
     def __init__(self, *args: t.Any, parent: _HasRecreateSubcommands, **kwargs: t.Any) -> None:
         super().__init__(*args, **kwargs)
         self.parents = [parent]
@@ -136,7 +134,7 @@ class OptionModifier(enum.Enum):
     """Consume rest option. This will consume the entire remainder of the string."""
 
 
-@dataclasses.dataclass
+@attrs.define(slots=True)
 class OptionLike:
     """
     Generic dataclass representing a command option. Compatible with both prefix and application commands.
@@ -184,13 +182,13 @@ class OptionLike:
     """
     autocomplete: bool = False
     """Whether the option should be autocompleted or not. This only affects slash commands."""
-    name_localizations: t.Mapping[t.Union[hikari.Locale, str], str] = dataclasses.field(default_factory=dict)
+    name_localizations: t.Mapping[t.Union[hikari.Locale, str], str] = attrs.field(factory=dict)
     """
     A mapping of locale to name localizations for this option
 
     .. versionadded:: 2.3.0
     """
-    description_localizations: t.Mapping[t.Union[hikari.Locale, str], str] = dataclasses.field(default_factory=dict)
+    description_localizations: t.Mapping[t.Union[hikari.Locale, str], str] = attrs.field(factory=dict)
     """
     A mapping of locale to description localizations for this option
 
@@ -274,7 +272,7 @@ class OptionLike:
         return hikari.CommandOption(**kwargs)
 
 
-@dataclasses.dataclass
+@attrs.define(slots=True)
 class CommandLike:
     """Generic dataclass representing a command. This can be converted into any command object."""
 
@@ -284,19 +282,19 @@ class CommandLike:
     """The name of the command."""
     description: str
     """The description of the command."""
-    options: t.MutableMapping[str, OptionLike] = dataclasses.field(default_factory=dict)
+    options: t.MutableMapping[str, OptionLike] = attrs.field(factory=dict)
     """The options for the command."""
-    checks: t.Sequence[t.Union[checks.Check, checks._ExclusiveCheck]] = dataclasses.field(default_factory=list)
+    checks: t.Sequence[t.Union[checks.Check, checks._ExclusiveCheck]] = attrs.field(factory=list)
     """The checks for the command."""
     error_handler: t.Optional[
         t.Callable[[events.CommandErrorEvent], t.Coroutine[t.Any, t.Any, t.Optional[bool]]]
     ] = None
     """The error handler for the command."""
-    aliases: t.Sequence[str] = dataclasses.field(default_factory=list)
+    aliases: t.Sequence[str] = attrs.field(factory=list)
     """The aliases for the command. This only affects prefix commands."""
     guilds: hikari.UndefinedOr[t.Sequence[int]] = hikari.UNDEFINED
     """The guilds for the command. This only affects application commands."""
-    subcommands: t.List[CommandLike] = dataclasses.field(default_factory=list)
+    subcommands: t.List[CommandLike] = attrs.field(factory=list)
     """Subcommands for the command."""
     parser: t.Optional[t.Type[parser_.BaseParser]] = None
     """The argument parser to use for prefix commands."""
@@ -344,13 +342,13 @@ class CommandLike:
 
     .. versionadded:: 2.2.3
     """
-    name_localizations: t.Mapping[t.Union[hikari.Locale, str], str] = dataclasses.field(default_factory=dict)
+    name_localizations: t.Mapping[t.Union[hikari.Locale, str], str] = attrs.field(factory=dict)
     """
     A mapping of locale to name localizations for this command
 
     .. versionadded:: 2.3.0
     """
-    description_localizations: t.Mapping[t.Union[hikari.Locale, str], str] = dataclasses.field(default_factory=dict)
+    description_localizations: t.Mapping[t.Union[hikari.Locale, str], str] = attrs.field(factory=dict)
     """
     A mapping of locale to description localizations for this command
 
@@ -379,7 +377,7 @@ class CommandLike:
                 ],
             ],
         ],
-    ] = dataclasses.field(default_factory=dict, init=False)
+    ] = attrs.field(factory=dict, init=False)
 
     async def __call__(self, context: context_.base.Context) -> None:
         await self.callback(context)

--- a/lightbulb/decorators.py
+++ b/lightbulb/decorators.py
@@ -389,7 +389,7 @@ def set_help(
             cmd_doc = inspect.getdoc(c_like.callback)
             if cmd_doc is None:
                 raise ValueError("docstring=True was provided but the command does not have a docstring")
-            getter = lambda _, __: cmd_doc  # type: ignore
+            getter = lambda _, __: cmd_doc
         else:
             assert text is not None
             getter = text

--- a/lightbulb/errors.py
+++ b/lightbulb/errors.py
@@ -110,8 +110,6 @@ class CommandNotFound(LightbulbError):
     is not found. This will only be raised for prefix commands.
     """
 
-    __slots__ = ("invoked_with",)
-
     def __init__(self, *args: t.Any, invoked_with: str) -> None:
         super().__init__(*args)
         self.invoked_with: str = invoked_with
@@ -125,8 +123,6 @@ class CommandInvocationError(LightbulbError):
     ``CommandInvocationError.__cause__`` or ``CommandInvocationError.original``.
     """
 
-    __slots__ = ("original",)
-
     def __init__(self, *args: t.Any, original: Exception) -> None:
         super().__init__(*args)
         self.original: Exception = original
@@ -139,8 +135,6 @@ class CommandIsOnCooldown(LightbulbError):
     Error raised when a command was on cooldown when it was attempted to be invoked.
     """
 
-    __slots__ = ("retry_after",)
-
     def __init__(self, *args: t.Any, retry_after: float) -> None:
         super().__init__(*args)
         self.retry_after: float = retry_after
@@ -151,8 +145,6 @@ class ConverterFailure(LightbulbError):
     """
     Error raised when option type conversion fails while prefix command arguments are being parsed.
     """
-
-    __slots__ = ("option", "raw_value")
 
     def __init__(self, *args: t.Any, opt: commands.base.OptionLike, raw: str) -> None:
         super().__init__(*args)
@@ -171,8 +163,6 @@ class NotEnoughArguments(LightbulbError):
     Error raised when a prefix command expects more options than could be parsed from the user's input.
     """
 
-    __slots__ = ("missing_options",)
-
     def __init__(self, *args: t.Any, missing: t.Sequence[commands.base.OptionLike]) -> None:
         super().__init__(*args)
         self.missing_options: t.Sequence[commands.base.OptionLike] = missing
@@ -183,8 +173,6 @@ class MissingRequiredAttachmentArgument(LightbulbError):
     """
     Error raised when a prefix command expects an attachment but none were supplied with the invocation.
     """
-
-    __slots__ = ("missing_option",)
 
     def __init__(self, *args: t.Any, missing: commands.base.OptionLike) -> None:
         super().__init__(*args)
@@ -197,8 +185,6 @@ class MaxConcurrencyLimitReached(LightbulbError):
     Error raised when the maximum number of allowed concurrent invocations for a command
     has been exceeded.
     """
-
-    __slots__ = ("bucket",)
 
     def __init__(self, *args: t.Any, bucket: t.Type[buckets.Bucket]) -> None:
         super().__init__(*args)
@@ -216,8 +202,6 @@ class CheckFailure(LightbulbError):
     to be raised then you can access it using ``CheckFailure.__cause__``, or in the case of
     multiple checks failing, via ``CheckFailure.causes`` (since version `2.2.1`).
     """
-
-    __slots__ = ("causes",)
 
     def __init__(self, *args: t.Any, causes: t.Optional[t.Sequence[Exception]] = None) -> None:
         super().__init__(*args)

--- a/lightbulb/help_command.py
+++ b/lightbulb/help_command.py
@@ -217,6 +217,8 @@ class DefaultHelpCommand(BaseHelpCommand):
     An implementation of the :obj:`~BaseHelpCommand` that the bot uses by default.
     """
 
+    __slots__ = ()
+
     @staticmethod
     async def _get_command_plugin_map(
         cmd_map: t.Mapping[str, commands.base.Command], context: context_.base.Context

--- a/lightbulb/internal.py
+++ b/lightbulb/internal.py
@@ -59,7 +59,7 @@ def _serialise_option(option: hikari.CommandOption) -> t.Dict[str, t.Any]:
         "choices": list(
             sorted(
                 [{"n": c.name, "v": c.value} for c in option.choices] if option.choices is not None else [],
-                key=lambda d: d["n"],  # type: ignore
+                key=lambda d: d["n"],
             )
         ),
         "options": [_serialise_option(o) for o in option.options] if option.options is not None else [],
@@ -92,7 +92,7 @@ def _serialise_lightbulb_command(command: base.ApplicationCommand) -> t.Dict[str
         "type": create_kwargs["type"],
         "name": create_kwargs["name"],
         "description": create_kwargs.get("description"),
-        "options": [_serialise_option(o) for o in sorted(create_kwargs.get("options", []), key=lambda o: o.name)],  # type: ignore
+        "options": [_serialise_option(o) for o in sorted(create_kwargs.get("options", []), key=lambda o: o.name)],
         "guild_id": _GuildIDCollection(command.guilds) if command.guilds else None,
         "default_member_permissions": command.app_command_default_member_permissions,
         "dm_enabled": command.app_command_dm_enabled if not command.guilds else False,

--- a/lightbulb/utils/data_store.py
+++ b/lightbulb/utils/data_store.py
@@ -48,6 +48,8 @@ class DataStore(t.Dict[str, t.Any]):
             DataStore()
     """
 
+    __slots__ = ()
+
     def __repr__(self) -> str:
         return "DataStore(" + ", ".join(f"{k}={v!r}" for k, v in self.items()) + ")"
 

--- a/lightbulb/utils/nav.py
+++ b/lightbulb/utils/nav.py
@@ -238,6 +238,8 @@ class ReactionNavigator(t.Generic[T]):
                 await navigator.run(ctx)
     """
 
+    __slots__ = ("pages", "buttons", "_timeout", "current_page_index", "_context", "_msg", "_timeout_task")
+
     def __init__(
         self,
         pages: t.Union[t.Iterable[T], t.Iterator[T]],
@@ -383,6 +385,8 @@ class ButtonNavigator(t.Generic[T]):
                 navigator = nav.ButtonNavigator(paginated_help.build_pages())
                 await navigator.run(ctx)
     """
+
+    __slots__ = ("pages", "buttons", "_timeout", "current_page_index", "_context", "_msg", "_timeout_task")
 
     def __init__(
         self,

--- a/lightbulb/utils/pag.py
+++ b/lightbulb/utils/pag.py
@@ -30,6 +30,20 @@ T = t.TypeVar("T")
 
 
 class Paginator(abc.ABC, t.Generic[T]):
+    __slots__ = (
+        "_max_total_chars",
+        "_max_total_lines",
+        "_max_content_chars",
+        "_max_content_lines",
+        "_line_separator",
+        "_page_prefix",
+        "_page_suffix",
+        "_next_page",
+        "_pages",
+        "_page_factory",
+        "current_page",
+    )
+
     @abc.abstractmethod
     def __init__(
         self,
@@ -210,6 +224,8 @@ class StringPaginator(Paginator[str]):
                     await ctx.respond(page)
     """
 
+    __slots__ = ()
+
     def __init__(
         self,
         *,
@@ -244,6 +260,8 @@ class EmbedPaginator(Paginator[hikari.Embed]):
         prefix (:obj:`str`): The string to prefix every page with. Defaults to an empty string.
         suffix (:obj:`str`): The string to suffix every page with. Defaults to an empty string.
     """
+
+    __slots__ = ()
 
     def __init__(
         self,


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->
- Improved slotting of various Lightbulb classes
    - Lightbulb's original slotting wasn't done overly correctly - slots applied to subclasses but not parent classes (so there were no real advantages), or slots applied to classes that inherited from builtin classes (so again, no advantages). I ran lightbulb through slotscheck and fixed all the errors it pointed out. Might be a good addition for the CI pipeline in future.
- Swapped dataclasses for attrs
    - While attempting to fix the slotting issues, I was having issues with dataclasses not working properly and complaining about the slots. I swapped it for attrs (which hikari already uses) and replaced everything appropriately - _hopefully_, there is no difference visible to the end user, because if I'm being honest, I haven't actually tested it.
- Mypy tests were failing because of two unnecessary `# type: ignore` comments. Those have been removed and mypy fully passes now.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.

<!--
### Related issues
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
