### PR TITLE
build: allow installation in python 3.12 environments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     zip_safe=False,
     install_requires=parse_requirements_file("requirements.txt"),
     extras_require={"crontrigger": parse_requirements_file("crontrigger_requirements.txt")},
-    python_requires=">=3.8.0,<3.12",
+    python_requires=">=3.8.0,<3.13",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: AsyncIO",


### PR DESCRIPTION
### Summary
Increase the range of compatible Python versions to include 3.12, which is now supported by hikari

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.

<!--
### Related issues
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
