### PR TITLE
Add Validators to Options in PrefixContext

### DIFF
--- a/lightbulb/errors.py
+++ b/lightbulb/errors.py
@@ -158,6 +158,21 @@ class ConverterFailure(LightbulbError):
         """
 
 
+class InvalidArgument(LightbulbError):
+    """
+    Error raised when the converted argument is invalid.
+    """
+
+    def __init__(self, *args: t.Any, opt: commands.base.OptionLike, value: t.Any) -> None:
+        super().__init__(*args)
+        self.option: commands.base.OptionLike = opt
+        """The option that failed the check."""
+        self.value: t.Any = value
+        """
+        The argument that didn't match the required criteria.
+        """
+
+
 class NotEnoughArguments(LightbulbError):
     """
     Error raised when a prefix command expects more options than could be parsed from the user's input.


### PR DESCRIPTION
### Summary
Add Validators to Options in PrefixContext
I always thought those were implemented but apparently not?
this is a huge security concern as its not mentioned clearly anywhere in the docs

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
