### PR TITLE
fix: use correct parameters for _get_bucket

### DIFF
--- a/docs/source/changelogs/v2-changelog.rst
+++ b/docs/source/changelogs/v2-changelog.rst
@@ -6,6 +6,11 @@ Below are all the changelogs for the stable versions of hikari-lightbulb (versio
 
 ----
 
+Version 2.3.5
+=============
+
+- Fix incorrect parameters being passed to _get_bucket which prevented the add_cooldown decorator from functioning correctly.
+
 Version 2.3.4
 =============
 

--- a/lightbulb/__init__.py
+++ b/lightbulb/__init__.py
@@ -191,4 +191,4 @@ from lightbulb.help_command import *
 from lightbulb.parser import *
 from lightbulb.plugins import *
 
-__version__ = "2.3.4"
+__version__ = "2.3.5"

--- a/lightbulb/decorators.py
+++ b/lightbulb/decorators.py
@@ -336,12 +336,12 @@ def add_cooldown(
             ctx: context.base.Context,
             _bucket: t.Type[buckets.Bucket],
             _length: float,
-            _max_usages: int,
+            _uses: int,
             _algorithm: t.Type[cooldown_algorithms.CooldownAlgorithm],
         ) -> buckets.Bucket:
-            return _bucket(_length, _max_usages, _algorithm)
+            return _bucket(_length, _uses, _algorithm)
 
-        getter = functools.partial(_get_bucket, b=bucket, l=length, u=uses, a=algorithm)
+        getter = functools.partial(_get_bucket, _bucket=bucket, _length=length, _uses=uses, _algorithm=algorithm)
     elif callback is not None:
         getter = callback
     else:


### PR DESCRIPTION
### Summary
This bug was introduced in b189899

I failed to notice that I hadn't changed the supplied parameters in all locations. This fix should allow `add_cooldown` to work again.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.

### Related issues
#lightbulb in the hikari server - https://discord.com/channels/574921006817476608/727982024660615198/1182721287450280078
