### PR TITLE
Fix incorrect validation logic

### DIFF
--- a/lightbulb/parser.py
+++ b/lightbulb/parser.py
@@ -287,9 +287,9 @@ class Parser(BaseParser):
         if option.min_length and len(arg) < option.min_length:
             raise errors.InvalidArgument("Value too short", opt=option, value=arg)
 
-        if option.min_value and len(arg) < option.min_value:
+        if option.min_value < option.min_value:
             raise errors.InvalidArgument("Value too small", opt=option, value=arg)
-        if option.max_value and len(arg) > option.max_value:
+        if option.max_value > option.max_value:
             raise errors.InvalidArgument("Value too big", opt=option, value=arg)
         if option.choices and arg not in option.choices:
             raise errors.InvalidArgument("Value not in available choices", opt=option, value=arg)


### PR DESCRIPTION
### Summary
Fixed incorrect validation logic

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
