### PR TITLE
Fix Tanjun URL

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,7 +40,7 @@ you should submit an issue on the GitHub repository `here <https://github.com/ta
 Before doing so you should make sure you are on the latest version of the library and check to see if an issue
 already exists for your bug or feature.
 
-Also see `Tanjun <https://fasterspeeding.github.io/Tanjun/master/>`_ if you would prefer different command handler
+Also see `Tanjun <https://tanjun.cursed.solutions/>`_ if you would prefer different command handler
 syntax. I recommend taking a look at both Lightbulb and Tanjun before choosing which one you wish to use for your bot.
 
 `View Tanjun on GitHub <https://github.com/FasterSpeeding/Tanjun>`_


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->
https://fasterspeeding.github.io/Tanjun has a HTTP 301 to https://tanjun.cursed.solutions/

[FasterSpeeding/Tanjun/docs/CNAME](https://github.com/FasterSpeeding/Tanjun/blob/docs/CNAME)

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->