### PR TITLE
Fix Hikari URL in readthedocs

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -14,7 +14,7 @@ ogp_description_length: 148
 
 ## Overview
 
-**Lightbulb** is a command handler library designed for use with [Hikari](https://github.com/hikari-py/hikari>).
+**Lightbulb** is a command handler library designed for use with [Hikari](https://github.com/hikari-py/hikari).
 
 It aims to provide an easy-to-use interface for building commands with your bot.
 


### PR DESCRIPTION
remove incorrect trailing ">" character from Hikari URL

### Summary
<!-- Small summary of the pull request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
<!-- 
    The below is done by creating the following file:
    `fragments/{PR_NUMBER}.(documentation|feature|bugfix).md`
    (e.g. `fragments/1234.feature.md`)
    containing a brief overview of the changes made by the PR
-->
- [ ] I have created a changelog fragment to describe this change

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a pull request use `#pull-request-id`
To close/fix an issue use `Closes #issue-id` or `Fixes #issue-id` (depending on the pull request)
-->
