### PR TITLE
docs: Add missing closing parenthesis

### DIFF
--- a/lightbulb/client.py
+++ b/lightbulb/client.py
@@ -344,7 +344,7 @@ class Client(abc.ABC):
 
             .. code-block:: python
 
-                @client.task(lightbulb.uniformtrigger(minutes=1)
+                @client.task(lightbulb.uniformtrigger(minutes=1))
                 async def print_hi() -> None:
                     print("HI")
         """


### PR DESCRIPTION
### Summary

Documentation only change, fixes a typo that missed a closing `)`
