### PR TITLE
feat: user installable commands

### DIFF
--- a/fragments/536.feature.md
+++ b/fragments/536.feature.md
@@ -1,0 +1,1 @@
+Implement user installable application commands.

--- a/lightbulb/commands/commands.py
+++ b/lightbulb/commands/commands.py
@@ -73,8 +73,11 @@ class CommandData:
     """Whether the command name and description should be localized."""
     nsfw: bool = dataclasses.field(repr=False)
     """Whether the command is marked as nsfw."""
-    dm_enabled: bool = dataclasses.field(repr=False)
-    """Whether the command is enabled in direct messages. This field is ignored for subcommands."""
+
+    integration_types: hikari.UndefinedOr[Sequence[hikari.ApplicationIntegrationType]] = dataclasses.field(repr=False)
+    """Installations contexts where the command is available. Only affects global commands."""
+    contexts: hikari.UndefinedOr[Sequence[hikari.ApplicationContextType]] = dataclasses.field(repr=False)
+    """Interaction contexts where the command can be used. Only affects global commands."""
     default_member_permissions: hikari.UndefinedOr[hikari.Permissions] = dataclasses.field(repr=False)
     """The default permissions required to use the command in a guild. This field is ignored for subcommands."""
 
@@ -143,8 +146,9 @@ class CommandData:
                 hikari.impl.SlashCommandBuilder(name=name, description=description)
                 .set_name_localizations(name_localizations)  # type: ignore[reportArgumentType]
                 .set_description_localizations(description_localizations)  # type: ignore[reportArgumentType]
-                .set_is_dm_enabled(self.dm_enabled)
                 .set_default_member_permissions(self.default_member_permissions)
+                .set_integration_types(self.integration_types)
+                .set_context_types(self.contexts)
             )
             for option in self.options.values():
                 bld.add_option(await option.to_command_option(default_locale, localization_provider))
@@ -154,8 +158,9 @@ class CommandData:
         return (
             hikari.impl.ContextMenuCommandBuilder(type=self.type, name=self.name)
             .set_name_localizations(name_localizations)  # type: ignore[reportArgumentType]
-            .set_is_dm_enabled(self.dm_enabled)
             .set_default_member_permissions(self.default_member_permissions)
+            .set_integration_types(self.integration_types)
+            .set_context_types(self.contexts)
         )
 
     async def to_command_option(
@@ -254,7 +259,11 @@ class CommandMeta(type):
 
         localize: bool = kwargs.pop("localize", False)
         nsfw: bool = kwargs.pop("nsfw", False)
-        dm_enabled: bool = kwargs.pop("dm_enabled", True)
+
+        integration_types: hikari.UndefinedOr[Sequence[hikari.ApplicationIntegrationType]] = kwargs.pop(
+            "integration_types", hikari.UNDEFINED
+        )
+        contexts: hikari.UndefinedOr[Sequence[hikari.ApplicationContextType]] = kwargs.pop("contexts", hikari.UNDEFINED)
         default_member_permissions: hikari.UndefinedOr[hikari.Permissions] = kwargs.pop(
             "default_member_permissions", hikari.UNDEFINED
         )
@@ -292,7 +301,8 @@ class CommandMeta(type):
             description=description,
             localize=localize,
             nsfw=nsfw,
-            dm_enabled=dm_enabled,
+            integration_types=integration_types,
+            contexts=contexts,
             default_member_permissions=default_member_permissions,
             hooks=hooks,
             options=options,

--- a/lightbulb/commands/groups.py
+++ b/lightbulb/commands/groups.py
@@ -34,6 +34,7 @@ from lightbulb.commands import utils
 if t.TYPE_CHECKING:
     from collections.abc import Callable
     from collections.abc import Mapping
+    from collections.abc import Sequence
 
     from lightbulb import localization
 
@@ -122,7 +123,8 @@ class SubGroup(GroupMixin):
             self.description,
             self.localize,
             self.parent.nsfw,
-            self.parent.dm_enabled,
+            self.parent.integration_types,
+            self.parent.contexts,
             self.parent.default_member_permissions,
             [],
             {},
@@ -187,8 +189,14 @@ class Group(GroupMixin):
     """Whether the group name and description should be localized."""
     nsfw: bool = dataclasses.field(repr=False, default=False)
     """Whether the group should be marked as nsfw. Defaults to :obj:`False`."""
-    dm_enabled: bool = dataclasses.field(repr=False, default=True)
-    """Whether the group is enabled in direct messages."""
+    integration_types: hikari.UndefinedOr[Sequence[hikari.ApplicationIntegrationType]] = dataclasses.field(
+        repr=False, default=hikari.UNDEFINED
+    )
+    """Installations contexts where the command is available. Only affects global commands."""
+    contexts: hikari.UndefinedOr[Sequence[hikari.ApplicationContextType]] = dataclasses.field(
+        repr=False, default=hikari.UNDEFINED
+    )
+    """Interaction contexts where the command can be used. Only affects global commands."""
     default_member_permissions: hikari.UndefinedOr[hikari.Permissions] = dataclasses.field(
         repr=False, default=hikari.UNDEFINED
     )
@@ -204,7 +212,8 @@ class Group(GroupMixin):
             self.description,
             self.localize,
             self.nsfw,
-            self.dm_enabled,
+            self.integration_types,
+            self.contexts,
             self.default_member_permissions,
             [],
             {},
@@ -260,8 +269,9 @@ class Group(GroupMixin):
             .set_name_localizations(name_localizations)  # type: ignore[reportArgumentType]
             .set_description_localizations(description_localizations)  # type: ignore[reportArgumentType]
             .set_is_nsfw(self.nsfw)
-            .set_is_dm_enabled(self.dm_enabled)
             .set_default_member_permissions(self.default_member_permissions)
+            .set_integration_types(self.integration_types)
+            .set_context_types(self.contexts)
         )
 
         for command_or_group in self._commands.values():

--- a/lightbulb/metaparams.json
+++ b/lightbulb/metaparams.json
@@ -7,7 +7,8 @@
     "optional": {
       "localize": "bool",
       "nsfw": "bool",
-      "dm_enabled": "bool",
+      "integration_types": "list[hikari.applications.ApplicationIntegrationType]",
+      "contexts": "list[hikari.applications.ApplicationContextType]",
       "default_member_permissions": "hikari.permissions.Permissions",
       "hooks": "list[lightbulb.ExecutionHook]"
     }
@@ -19,7 +20,8 @@
     "optional": {
       "localize": "bool",
       "nsfw": "bool",
-      "dm_enabled": "bool",
+      "integration_types": "list[hikari.applications.ApplicationIntegrationType]",
+      "contexts": "list[hikari.applications.ApplicationContextType]",
       "default_member_permissions": "hikari.permissions.Permissions",
       "hooks": "list[lightbulb.ExecutionHook]"
     }
@@ -31,7 +33,8 @@
     "optional": {
       "localize": "bool",
       "nsfw": "bool",
-      "dm_enabled": "bool",
+      "integration_types": "list[hikari.applications.ApplicationIntegrationType]",
+      "contexts": "list[hikari.applications.ApplicationContextType]",
       "default_member_permissions": "hikari.permissions.Permissions",
       "hooks": "list[lightbulb.ExecutionHook]"
     }

--- a/lightbulb/prefab/checks.py
+++ b/lightbulb/prefab/checks.py
@@ -145,7 +145,7 @@ def bot_has_permissions(permissions: hikari.Permissions, /, *, fail_in_dm: bool 
 
     @execution.hook(execution.ExecutionSteps.CHECKS, skip_when_failed=True, name="bot_has_permissions")
     def _bot_has_permissions(_: execution.ExecutionPipeline, ctx: context.Context) -> None:
-        if ctx.interaction.app_permissions is None:
+        if ctx.guild_id is None:
             if fail_in_dm:
                 raise BotMissingRequiredPermissions(permissions, hikari.Permissions.NONE)
             return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]
-dependencies = ["hikari~=2.1.0", "async-timeout>=4, <6"]
+dependencies = ["hikari~=2.2.0", "async-timeout>=4, <6"]
 dynamic = ["version", "description"]
 
 [project.urls]

--- a/tests/prefab/test_checks.py
+++ b/tests/prefab/test_checks.py
@@ -126,14 +126,14 @@ class TestBotHasPermissions:
 
     @pytest.mark.asyncio
     async def test_fails_when_not_in_guild(self, context: lightbulb.Context) -> None:
-        context.interaction.app_permissions = None
+        context.guild_id = None  # type: ignore[reportAttributeAccess]
 
         with pytest.raises(lightbulb.prefab.BotMissingRequiredPermissions):
             await lightbulb.prefab.bot_has_permissions(hikari.Permissions.ADMINISTRATOR)(mock.Mock(), context)
 
     @pytest.mark.asyncio
     async def test_passes_when_not_in_guild_fail_flag_disabled(self, context: lightbulb.Context) -> None:
-        context.interaction.app_permissions = None
+        context.guild_id = None  # type: ignore[reportAttributeAccess]
         await lightbulb.prefab.bot_has_permissions(hikari.Permissions.ADMINISTRATOR, fail_in_dm=False)(
             mock.Mock(), context
         )


### PR DESCRIPTION
### Summary
Implement user installable application commands.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
<!-- 
    The below is done by creating the following file:
    `fragments/{PR_NUMBER}.(documentation|feature|bugfix).md`
    (e.g. `fragments/1234.feature.md`)
    containing a brief overview of the changes made by the PR
-->
- [x] I have created a changelog fragment to describe this change

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a pull request use `#pull-request-id`
To close/fix an issue use `Closes #issue-id` or `Fixes #issue-id` (depending on the pull request)
-->
https://github.com/hikari-py/hikari/pull/2195
