### PR TITLE
Implement command option converters

### DIFF
--- a/fragments/574.feature.md
+++ b/fragments/574.feature.md
@@ -1,0 +1,1 @@
+Implement option converters, allowing conversion of option values to custom types.

--- a/lightbulb/client.py
+++ b/lightbulb/client.py
@@ -1121,6 +1121,12 @@ class Client(abc.ABC):
 
         options, command = out
         context = self.build_command_context(interaction, options or [], command, initial_response_sent)
+        async with (
+                self.di.enter_context(di_.Contexts.DEFAULT),
+                self.di.enter_context(di_.Contexts.OPTION_CONVERSION) as container
+        ):
+            container.add_value(context_.Context, context)
+            await context.command._resolve_options()
         LOGGER.debug("invoking command - %r", command._command_data.qualified_name)
         await self._execute_command_context(context)
 

--- a/lightbulb/client.py
+++ b/lightbulb/client.py
@@ -1121,12 +1121,6 @@ class Client(abc.ABC):
 
         options, command = out
         context = self.build_command_context(interaction, options or [], command, initial_response_sent)
-        async with (
-                self.di.enter_context(di_.Contexts.DEFAULT),
-                self.di.enter_context(di_.Contexts.OPTION_CONVERSION) as container
-        ):
-            container.add_value(context_.Context, context)
-            await context.command._resolve_options()
         LOGGER.debug("invoking command - %r", command._command_data.qualified_name)
         await self._execute_command_context(context)
 

--- a/lightbulb/commands/commands.py
+++ b/lightbulb/commands/commands.py
@@ -383,7 +383,7 @@ class CommandBase:
                 # error lol
                 raise ValueError("no option resolved and no default provided")
 
-            return option._data.default if not option._converter else option._convert(option._data.default)
+            return option._data.default
 
         if option._data.type in _PRIMITIVE_OPTION_TYPES:
             self._resolved_option_cache[option._data._localized_name] = converted = found[0].value if not option._converter else option._convert(found[0].value)

--- a/lightbulb/commands/commands.py
+++ b/lightbulb/commands/commands.py
@@ -365,11 +365,11 @@ class CommandBase:
     async def _convert_option(
         self, option: options_.OptionData[OptionDefaultT, ConverterReturnT], value: t.Any
     ) -> ConverterReturnT:
-        if not self._current_context:
-            raise RuntimeError("tried to convert an option before setting context")
+        if self._current_context is None:
+            raise RuntimeError("cannot convert an option before context is available")
 
-        if not option.converter:
-            raise RuntimeError("tried to convert an option without a converter")
+        if option.converter is None:
+            raise RuntimeError("cannot convert an option without a converter")
 
         try:
             return await main_utils.maybe_await(option.converter(self._current_context, value))

--- a/lightbulb/commands/commands.py
+++ b/lightbulb/commands/commands.py
@@ -383,11 +383,11 @@ class CommandBase:
                 # error lol
                 raise ValueError("no option resolved and no default provided")
 
-            return option._data.default
+            return option._data.default if not option._converter else option._convert(option._data.default)
 
         if option._data.type in _PRIMITIVE_OPTION_TYPES:
-            self._resolved_option_cache[option._data._localized_name] = found[0].value
-            return t.cast("T", found[0].value)
+            self._resolved_option_cache[option._data._localized_name] = converted = found[0].value if not option._converter else option._convert(found[0].value)
+            return t.cast("T", converted)
 
         snowflake = found[0].value
         resolved = context.interaction.resolved
@@ -408,8 +408,8 @@ class CommandBase:
         else:
             raise TypeError("unsupported option type passed")
 
-        self._resolved_option_cache[option._data._localized_name] = resolved_option
-        return t.cast("T", resolved_option)
+        self._resolved_option_cache[option._data._localized_name] = converted = resolved_option if not option._converter else option._convert(resolved_option)
+        return t.cast("T", converted)
 
     @classmethod
     async def as_command_builder(

--- a/lightbulb/commands/commands.py
+++ b/lightbulb/commands/commands.py
@@ -370,7 +370,7 @@ class CommandBase:
             raise RuntimeError("cannot resolve options if no context is available")
 
         named_interaction_options = {option.name: option for option in context.options}
-        named_options: dict[str, options_.Option] = {option._data._localized_name: option for option in filter(lambda attr: isinstance(attr, options_.Option), vars(type(self)).values())}
+        named_options = {option._data._localized_name: option for option in filter(lambda attr: isinstance(attr, options_.Option), vars(type(self)).values())}
 
         for name, option in named_options.items():
             if (name not in named_interaction_options.keys()) or (option._data.type not in _PRIMITIVE_OPTION_TYPES and context.interaction.resolved is None):

--- a/lightbulb/commands/commands.py
+++ b/lightbulb/commands/commands.py
@@ -383,29 +383,28 @@ class CommandBase:
 
             value = named_interaction_options[name].value
             if option._data.type in _PRIMITIVE_OPTION_TYPES:
-                self._resolved_option_cache[name] = value if not option._converter else await option._convert(context, value)
+                self._resolved_option_cache[name] = value if not option._converter else await option._convert(value)
                 continue
 
-            snowflake = value
             resolved = context.interaction.resolved
             option_type = option._data.type
 
-            assert isinstance(snowflake, hikari.Snowflake)
+            assert isinstance(value, hikari.Snowflake)
             assert resolved is not None
 
             resolved_option: t.Any
             if option_type is hikari.OptionType.USER:
-                resolved_option = resolved.members.get(snowflake) or resolved.users[snowflake]
+                resolved_option = resolved.members.get(value) or resolved.users[value]
             elif option_type is hikari.OptionType.ROLE:
-                resolved_option = resolved.roles[snowflake]
+                resolved_option = resolved.roles[value]
             elif option_type is hikari.OptionType.CHANNEL:
-                resolved_option = resolved.channels[snowflake]
+                resolved_option = resolved.channels[value]
             elif option_type is hikari.OptionType.ATTACHMENT:
-                resolved_option = resolved.attachments[snowflake]
+                resolved_option = resolved.attachments[value]
             else:
                 raise TypeError("unsupported option type passed")
 
-            self._resolved_option_cache[name] = resolved_option if not option._converter else await option._convert(context, resolved_option)
+            self._resolved_option_cache[name] = resolved_option if not option._converter else await option._convert(resolved_option)
 
     @classmethod
     async def as_command_builder(

--- a/lightbulb/commands/execution.py
+++ b/lightbulb/commands/execution.py
@@ -235,6 +235,7 @@ class ExecutionPipeline:
         while self._current_step is not None:
             if self._current_step == ExecutionSteps.INVOKE and not self.failed:
                 try:
+                    await self._context.command._resolve_options()
                     await getattr(self._context.command, self._context.command_data.invoke_method)(self._context)
                     self._current_step = self._next_step()
                 except Exception as e:

--- a/lightbulb/commands/execution.py
+++ b/lightbulb/commands/execution.py
@@ -235,6 +235,7 @@ class ExecutionPipeline:
         while self._current_step is not None:
             if self._current_step == ExecutionSteps.INVOKE and not self.failed:
                 try:
+                    # TODO - allow users to choose when this is done?
                     await self._context.command._resolve_options()
                     await getattr(self._context.command, self._context.command_data.invoke_method)(self._context)
                     self._current_step = self._next_step()

--- a/lightbulb/commands/options.py
+++ b/lightbulb/commands/options.py
@@ -279,7 +279,7 @@ class ContextMenuOption(Option[CtxMenuOptionReturn, CtxMenuOptionReturn]):
         self, instance: commands.MessageCommand | None, owner: type[commands.MessageCommand]
     ) -> hikari.Message: ...
 
-    def __get__(self, instance: commands.CommandBase | None, owner: type[commands.CommandBase]) -> CtxMenuOptionReturn | T:
+    def __get__(self, instance: commands.CommandBase | None, owner: type[commands.CommandBase]) -> CtxMenuOptionReturn:
         if instance is None or getattr(instance, "_current_context", None) is None:
             return self._unbound_default
 

--- a/lightbulb/commands/options.py
+++ b/lightbulb/commands/options.py
@@ -637,7 +637,7 @@ def user(
     description: str,
     /,
     *,
-    converter: t.Callable[[context.Context, hikari.User], t.Awaitable[ConvertedT]],
+    converter: t.Callable[[context.Context, hikari.User], types.MaybeAwaitable[ConvertedT]],
     localize: bool = False,
     default: hikari.UndefinedOr[DefaultT] = hikari.UNDEFINED,
 ) -> DefaultT | ConvertedT: ...
@@ -648,7 +648,7 @@ def user(
     description: str,
     /,
     *,
-    converter: t.Callable[[context.Context, hikari.User], t.Awaitable[ConvertedT]] | None = None,
+    converter: t.Callable[[context.Context, hikari.User], types.MaybeAwaitable[ConvertedT]] | None = None,
     localize: bool = False,
     default: hikari.UndefinedOr[DefaultT] = hikari.UNDEFINED,
 ) -> hikari.User | DefaultT | ConvertedT:
@@ -701,7 +701,7 @@ def channel(
     description: str,
     /,
     *,
-    converter: t.Callable[[context.Context, hikari.PartialChannel], t.Awaitable[ConvertedT]],
+    converter: t.Callable[[context.Context, hikari.PartialChannel], types.MaybeAwaitable[ConvertedT]],
     localize: bool = False,
     default: hikari.UndefinedOr[DefaultT] = hikari.UNDEFINED,
     channel_types: hikari.UndefinedOr[Sequence[hikari.ChannelType]] = hikari.UNDEFINED,
@@ -713,7 +713,7 @@ def channel(
     description: str,
     /,
     *,
-    converter: t.Callable[[context.Context, hikari.PartialChannel], t.Awaitable[ConvertedT]] | None = None,
+    converter: t.Callable[[context.Context, hikari.PartialChannel], types.MaybeAwaitable[ConvertedT]] | None = None,
     localize: bool = False,
     default: hikari.UndefinedOr[DefaultT] = hikari.UNDEFINED,
     channel_types: hikari.UndefinedOr[Sequence[hikari.ChannelType]] = hikari.UNDEFINED,
@@ -768,7 +768,7 @@ def role(
     description: str,
     /,
     *,
-    converter: t.Callable[[context.Context, hikari.Role], t.Awaitable[ConvertedT]],
+    converter: t.Callable[[context.Context, hikari.Role], types.MaybeAwaitable[ConvertedT]],
     localize: bool = False,
     default: hikari.UndefinedOr[DefaultT] = hikari.UNDEFINED,
 ) -> DefaultT | ConvertedT: ...
@@ -779,7 +779,7 @@ def role(
     description: str,
     /,
     *,
-    converter: t.Callable[[context.Context, hikari.Role], t.Awaitable[ConvertedT]] | None = None,
+    converter: t.Callable[[context.Context, hikari.Role], types.MaybeAwaitable[ConvertedT]] | None = None,
     localize: bool = False,
     default: hikari.UndefinedOr[DefaultT] = hikari.UNDEFINED,
 ) -> hikari.Role | DefaultT | ConvertedT:
@@ -831,7 +831,7 @@ def mentionable(
     description: str,
     /,
     *,
-    converter: t.Callable[[context.Context, hikari.Snowflake], t.Awaitable[ConvertedT]],
+    converter: t.Callable[[context.Context, hikari.Snowflake], types.MaybeAwaitable[ConvertedT]],
     localize: bool = False,
     default: hikari.UndefinedOr[DefaultT] = hikari.UNDEFINED,
 ) -> DefaultT | ConvertedT: ...
@@ -842,7 +842,7 @@ def mentionable(
     description: str,
     /,
     *,
-    converter: t.Callable[[context.Context, hikari.Snowflake], t.Awaitable[ConvertedT]] | None = None,
+    converter: t.Callable[[context.Context, hikari.Snowflake], types.MaybeAwaitable[ConvertedT]] | None = None,
     localize: bool = False,
     default: hikari.UndefinedOr[DefaultT] = hikari.UNDEFINED,
 ) -> hikari.Snowflake | DefaultT | ConvertedT:
@@ -894,7 +894,7 @@ def attachment(
     description: str,
     /,
     *,
-    converter: t.Callable[[context.Context, hikari.Attachment], t.Awaitable[ConvertedT]],
+    converter: t.Callable[[context.Context, hikari.Attachment], types.MaybeAwaitable[ConvertedT]],
     localize: bool = False,
     default: hikari.UndefinedOr[DefaultT] = hikari.UNDEFINED,
 ) -> DefaultT | ConvertedT: ...
@@ -905,7 +905,7 @@ def attachment(
     description: str,
     /,
     *,
-    converter: t.Callable[[context.Context, hikari.Attachment], t.Awaitable[ConvertedT]] | None = None,
+    converter: t.Callable[[context.Context, hikari.Attachment], types.MaybeAwaitable[ConvertedT]] | None = None,
     localize: bool = False,
     default: hikari.UndefinedOr[DefaultT] = hikari.UNDEFINED,
 ) -> hikari.Attachment | DefaultT | ConvertedT:

--- a/lightbulb/commands/options.py
+++ b/lightbulb/commands/options.py
@@ -244,7 +244,7 @@ class Option(t.Generic[T, D]):
             raise ConversionFailedException from e
 
 
-class ContextMenuOption[T](Option[CtxMenuOptionReturn, CtxMenuOptionReturn]):
+class ContextMenuOption(Option[CtxMenuOptionReturn, CtxMenuOptionReturn]):
     """
     Special implementation of :obj:`~Option` to handle context menu command targets given that
     they do not count as an "option" and the ID is instead given through the ``target`` field on the
@@ -260,7 +260,7 @@ class ContextMenuOption[T](Option[CtxMenuOptionReturn, CtxMenuOptionReturn]):
 
     __slots__ = ("_type",)
 
-    def __init__(self, type_: type[CtxMenuOptionReturn], converter: t.Callable[[CtxMenuOptionReturn], T] | None = None) -> None:
+    def __init__(self, type_: type[CtxMenuOptionReturn]) -> None:
         self._type = type_
         super().__init__(
             OptionData(
@@ -269,7 +269,6 @@ class ContextMenuOption[T](Option[CtxMenuOptionReturn, CtxMenuOptionReturn]):
                 description="target",
             ),
             utils.EMPTY,
-            converter=converter
         )
 
     @t.overload
@@ -279,11 +278,6 @@ class ContextMenuOption[T](Option[CtxMenuOptionReturn, CtxMenuOptionReturn]):
     def __get__(
         self, instance: commands.MessageCommand | None, owner: type[commands.MessageCommand]
     ) -> hikari.Message: ...
-
-    @t.overload
-    def __get__(
-        self, instance: commands.MessageCommand | commands.UserCommand | None, owner: type[commands.MessageCommand] | type[commands.UserCommand]
-    ) -> T: ...
 
     def __get__(self, instance: commands.CommandBase | None, owner: type[commands.CommandBase]) -> CtxMenuOptionReturn | T:
         if instance is None or getattr(instance, "_current_context", None) is None:
@@ -298,11 +292,11 @@ class ContextMenuOption[T](Option[CtxMenuOptionReturn, CtxMenuOptionReturn]):
         if self._type is hikari.User:
             user = resolved.members.get(interaction.target_id) or resolved.users.get(interaction.target_id)
             assert isinstance(user, hikari.User)
-            return user if not self._converter else self._convert(user)
+            return user
 
         message = resolved.messages.get(interaction.target_id)
         assert isinstance(message, hikari.Message)
-        return message if not self._converter else self._convert(message)
+        return message
 
 @t.overload
 def string(

--- a/lightbulb/commands/options.py
+++ b/lightbulb/commands/options.py
@@ -57,7 +57,7 @@ if t.TYPE_CHECKING:
     from lightbulb import commands
     from lightbulb import context
     from lightbulb import localization
-    from lightbulb.utils import MaybeAwaitable
+    from lightbulb.internal import types
 
     AutocompleteProvider = Callable[[context.AutocompleteContext[context.T]], Awaitable[t.Any]]
 
@@ -229,7 +229,7 @@ class Option(t.Generic[T, D]):
 
     __slots__ = ("_data", "_unbound_default", "_converter")
 
-    def __init__(self, data: OptionData[D], default_when_not_bound: T, converter: t.Callable[[D], MaybeAwaitable[T]] | None = None) -> None:
+    def __init__(self, data: OptionData[D], default_when_not_bound: T, converter: t.Callable[[D], types.MaybeAwaitable[T]] | None = None) -> None:
         self._data = data
         self._unbound_default = default_when_not_bound
         self._converter = converter
@@ -241,11 +241,11 @@ class Option(t.Generic[T, D]):
         if not self._data._localized_name in instance._resolved_option_cache.keys():
             raise RuntimeError(f"Tried to access option {self._data._localized_name} before resolving options.")
 
-        return t.cast(T, instance._resolved_option_cache[self._data._localized_name])
+        return t.cast("T", instance._resolved_option_cache[self._data._localized_name])
 
     async def _convert(self, value: D) -> T:
         try:
-            return t.cast(T, await maybe_await(di.with_di(self._converter)(value)))
+            return t.cast("T", await maybe_await(di.with_di(self._converter)(value)))
         except Exception as e:
             raise ConversionFailedException(f"Failed to convert {value} for option {self._data._localized_name}") from e
 
@@ -323,7 +323,7 @@ def string(
     description: str,
     /,
     *,
-    converter: t.Callable[[str], MaybeAwaitable[T]],
+    converter: t.Callable[[str], types.MaybeAwaitable[T]],
     localize: bool = False,
     default: hikari.UndefinedOr[D] = hikari.UNDEFINED,
     choices: hikari.UndefinedOr[Sequence[Choice[str]]] = hikari.UNDEFINED,
@@ -337,7 +337,7 @@ def string(
     description: str,
     /,
     *,
-    converter: t.Callable[[str], MaybeAwaitable[T]] | None = None,
+    converter: t.Callable[[str], types.MaybeAwaitable[T]] | None = None,
     localize: bool = False,
     default: hikari.UndefinedOr[D] = hikari.UNDEFINED,
     choices: hikari.UndefinedOr[Sequence[Choice[str]]] = hikari.UNDEFINED,
@@ -380,7 +380,7 @@ def string(
         utils.EMPTY,
         converter=converter,
     )
-    return t.cast("str", opt) if not converter else t.cast(T, opt)
+    return t.cast("str", opt) if not converter else t.cast("T", opt)
 
 
 def integer(

--- a/lightbulb/exceptions.py
+++ b/lightbulb/exceptions.py
@@ -27,20 +27,24 @@ exceptions raised by the dependency injection system are vendored by the ``light
 from __future__ import annotations
 
 __all__ = [
+    "ConversionFailedException",
     "ExecutionException",
     "ExecutionPipelineFailedException",
     "LightbulbException",
     "LocalizationFailedException",
-    "ConversionFailedException"
 ]
 
 import typing as t
+
+T = t.TypeVar("T")
+D = t.TypeVar("D")
 
 if t.TYPE_CHECKING:
     from collections.abc import Sequence
 
     from lightbulb import context as context_
     from lightbulb.commands import execution
+    from lightbulb.commands import options
 
 
 class LightbulbException(Exception):
@@ -53,10 +57,17 @@ class LocalizationFailedException(LightbulbException):
     could not be resolved.
     """
 
+
 class ConversionFailedException(LightbulbException):
-    """
-    Exception raised when a command option conversion fails.
-    """
+    """Exception raised when a command option conversion fails."""
+
+    def __init__(self, context: context_.Context, option: options.Option[T, D], value: D) -> None:
+        super().__init__(f"Failed to convert option {option._data._localized_name}.")
+        self.context: context_.Context = context
+        self.name = option._data._localized_name
+        self.default = option._data.default
+        self.value = value
+
 
 class ExecutionException(LightbulbException):
     """Base class for exceptions that can be encountered during a command execution pipeline."""

--- a/lightbulb/exceptions.py
+++ b/lightbulb/exceptions.py
@@ -36,8 +36,8 @@ __all__ = [
 
 import typing as t
 
-T = t.TypeVar("T")
 D = t.TypeVar("D")
+R = t.TypeVar("R")
 
 if t.TYPE_CHECKING:
     from collections.abc import Sequence
@@ -61,12 +61,13 @@ class LocalizationFailedException(LightbulbException):
 class ConversionFailedException(LightbulbException):
     """Exception raised when a command option conversion fails."""
 
-    def __init__(self, context: context_.Context, option: options.Option[T, D], value: D) -> None:
-        super().__init__(f"Failed to convert option {option._data._localized_name}.")
-        self.context: context_.Context = context
-        self.name = option._data._localized_name
-        self.default = option._data.default
-        self.value = value
+    def __init__(self, option: options.OptionData[D, R], value: t.Any) -> None:
+        super().__init__(f"failed converting option {option._localized_name!r}")
+
+        self.option: options.OptionData[t.Any, t.Any] = option
+        """The data for the option that failed conversion."""
+        self.value: t.Any = value
+        """The value which could not be converted."""
 
 
 class ExecutionException(LightbulbException):

--- a/lightbulb/exceptions.py
+++ b/lightbulb/exceptions.py
@@ -31,6 +31,7 @@ __all__ = [
     "ExecutionPipelineFailedException",
     "LightbulbException",
     "LocalizationFailedException",
+    "ConversionFailedException"
 ]
 
 import typing as t

--- a/lightbulb/exceptions.py
+++ b/lightbulb/exceptions.py
@@ -52,6 +52,10 @@ class LocalizationFailedException(LightbulbException):
     could not be resolved.
     """
 
+class ConversionFailedException(LightbulbException):
+    """
+    Exception raised when a command option conversion fails.
+    """
 
 class ExecutionException(LightbulbException):
     """Base class for exceptions that can be encountered during a command execution pipeline."""

--- a/lightbulb/utils.py
+++ b/lightbulb/utils.py
@@ -20,12 +20,13 @@
 # SOFTWARE.
 from __future__ import annotations
 
-__all__ = ["EMPTY", "get_command_data"]
+__all__ = ["EMPTY", "get_command_data", "maybe_await", "MaybeAwaitable"]
 
 import inspect
 import typing as t
 
 from lightbulb.internal import marker
+from linkd.utils import MaybeAwaitable
 
 if t.TYPE_CHECKING:
     from lightbulb.commands import commands

--- a/lightbulb/utils.py
+++ b/lightbulb/utils.py
@@ -20,13 +20,12 @@
 # SOFTWARE.
 from __future__ import annotations
 
-__all__ = ["EMPTY", "get_command_data", "maybe_await", "MaybeAwaitable"]
+__all__ = ["EMPTY", "get_command_data", "maybe_await"]
 
 import inspect
 import typing as t
 
 from lightbulb.internal import marker
-from linkd.utils import MaybeAwaitable
 
 if t.TYPE_CHECKING:
     from lightbulb.commands import commands


### PR DESCRIPTION
### Summary
<!-- Small summary of the pull request -->
Implement command converters allowing users to provide a function to convert one of the Option Types into a custom type of their liking.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
<!-- 
    The below is done by creating the following file:
    `fragments/{PR_NUMBER}.(documentation|feature|bugfix).md`
    (e.g. `fragments/1234.feature.md`)
    containing a brief overview of the changes made by the PR
-->
- [ ] I have created a changelog fragment to describe this change

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a pull request use `#pull-request-id`
To close/fix an issue use `Closes #issue-id` or `Fixes #issue-id` (depending on the pull request)
-->
