### PR TITLE
Fix group unloading in client.unload_extensions

### DIFF
--- a/lightbulb/loaders.py
+++ b/lightbulb/loaders.py
@@ -116,6 +116,22 @@ class _CommandLoadable(Loadable):
 
     async def unload(self, client: client_.Client) -> None:
         client.unregister(self._command)
+        
+        # If this is a group, we need to manually remove all subcommands from the command invocation mapping
+        # since unregister() only handles the top-level group
+        if isinstance(self._command, groups.Group):
+            # Remove all subcommands and subgroups from the command invocation mapping
+            for guild_mapping in client._command_invocation_mapping.values():
+                # Create a copy of the keys to avoid modification during iteration
+                paths_to_remove = [
+                    command_path for command_path in list(guild_mapping.keys())
+                    if len(command_path) > 0 and command_path[0] == self._command.name
+                ]
+                
+                # Remove all paths associated with this group
+                for command_path in paths_to_remove:
+                    if command_path in guild_mapping:
+                        del guild_mapping[command_path]
 
 
 class _ListenerLoadable(Loadable):


### PR DESCRIPTION
The issue was that when unloading a group, only the top-level group was removed from the _command_invocation_mapping, but the subcommand paths remained. This happened because Client.unregister() only removes the command from collections but doesn't handle the hierarchical nature of groups and subcommands.

The fix ensures that when a group is unloaded, all of its subcommands are also properly removed from the command invocation mapping by identifying all command paths that start with the group's name and removing them from the mapping.

### Summary
<!-- Small summary of the pull request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
<!-- 
    The below is done by creating the following file:
    `fragments/{PR_NUMBER}.(documentation|feature|bugfix).md`
    (e.g. `fragments/1234.feature.md`)
    containing a brief overview of the changes made by the PR
-->
- [ ] I have created a changelog fragment to describe this change

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a pull request use `#pull-request-id`
To close/fix an issue use `Closes #issue-id` or `Fixes #issue-id` (depending on the pull request)
-->
