### PR TITLE
chore(deps): bump hikari version to 2.4.0

### DIFF
--- a/fragments/+hkver.misc.md
+++ b/fragments/+hkver.misc.md
@@ -1,0 +1,1 @@
+Bump Hikari version support to 2.4.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]
-dependencies = ["hikari~=2.3.1", "async-timeout>=4, <6", "linkd>=0.0.7", "confspec>=0.0.1", "typing-extensions>=4"]
+dependencies = ["hikari~=2.4.0", "async-timeout>=4, <6", "linkd>=0.0.7", "confspec>=0.0.1", "typing-extensions>=4"]
 dynamic = ["version", "description"]
 
 [project.urls]


### PR DESCRIPTION
### Summary
Bumps the minimum version of Hikari supported by Lightbulb to 2.4.0

### Checklist
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have created a changelog fragment to describe this change
- [ ] 
