### PR TITLE
Fix `KeyError` when syncing slash commands after unregistering a command group

### DIFF
--- a/fragments/699.bugfix.md
+++ b/fragments/699.bugfix.md
@@ -1,0 +1,1 @@
+Fix `KeyError` when syncing slash commands after unregistering a command group.

--- a/lightbulb/client.py
+++ b/lightbulb/client.py
@@ -651,12 +651,9 @@ class Client(abc.ABC):
         # If this is a group, we need to manually remove all subcommands from the command invocation mapping
         # since the collection.remove() only handles the top-level group
         if isinstance(command, groups.Group):
-            for guild_id, mapping in self._command_invocation_mapping.items():
-                self._command_invocation_mapping[guild_id] = {
-                    path: collection
-                    for path, collection in mapping.items()
-                    if not (len(path) > 1 and path[0] == command.name)
-                }
+            for mapping in self._command_invocation_mapping.values():
+                for path in [p for p in mapping if len(p) > 1 and p[0] == command.name]:
+                    del mapping[path]
         else:
             # For regular commands, just remove them from collections
             for mapping in self._command_invocation_mapping.values():


### PR DESCRIPTION
### Summary
When unregister is called, one of the code paths completely replaces a defaultdict with a normal dict. When adding commands to a group for which this happens, part of the code assumes the presence of thsi defaultdict and fails with a KeyError. This code fixes this by not replacing the defaultdict with a dict and instead modifying it in place for the unregister call.

### Checklist
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have created a changelog fragment to describe this change
