### PR TITLE
Fix `Loader.command` ignoring `global_` and `defer_guilds` when used as a second-order decorator

### DIFF
--- a/docs/source/by-examples/040_groups.md
+++ b/docs/source/by-examples/040_groups.md
@@ -84,4 +84,19 @@ client.register(group)
 client.register(group, guilds=[...])
 ```
 
+If the group is defined within an extension, register it with the `Loader` instead, using the `Loader.command`
+method. The group will then be registered with the client once the extension is loaded.
+
+```python
+loader = lightbulb.Loader()
+
+group = lightbulb.Group(...)
+
+...
+
+loader.command(group)
+# Like with the client, you can limit the command to specific guilds
+loader.command(group, guilds=[...])
+```
+
 After doing this - and starting the client - the command group's subcommands should appear within Discord and be usable.

--- a/fragments/720.bugfix.md
+++ b/fragments/720.bugfix.md
@@ -1,0 +1,1 @@
+Fix `Loader.command` ignoring the `global_` and `defer_guilds` arguments when used as a second-order decorator.

--- a/lightbulb/loaders.py
+++ b/lightbulb/loaders.py
@@ -304,9 +304,9 @@ class Loader:
                 loader = lightbulb.Loader()
 
                 # valid
-                @loader.register
+                @loader.command
                 # also valid
-                @loader.register(guilds=[...])
+                @loader.command(guilds=[...])
                 class Example(
                     lightbulb.SlashCommand,
                     ...
@@ -314,7 +314,7 @@ class Loader:
                     ...
 
                 # also valid
-                loader.register(Example, guilds=[...])
+                loader.command(Example, guilds=[...])
 
         See Also:
             :meth:`~lightbulb.client.Client.register`
@@ -326,7 +326,9 @@ class Loader:
 
         # Used as a second-order decorator
         def _inner(command_: CommandOrGroupT) -> CommandOrGroupT:
-            return self.command(command_, guilds=guilds)
+            if defer_guilds:
+                return self.command(command_, defer_guilds=True)
+            return self.command(command_, guilds=guilds, global_=global_)
 
         return _inner
 


### PR DESCRIPTION
### Summary
I just wanted claude code to rewrite the docstring for `Loader.command()` because it used `Loader.register()` in the example which doesn't exist. Claude code also found an bug so yeah fixed that too real quick. 

Hope you don't mind the added section to lightbulb-by-example, it was kinda hard to find out how to register group commands when i wrote my first v3 lightbulb bot so I added that.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
<!-- 
    The below is done by creating the following file:
    `fragments/{PR_NUMBER}.(documentation|feature|bugfix).md`
    (e.g. `fragments/1234.feature.md`)
    containing a brief overview of the changes made by the PR
-->
- [x] I have created a changelog fragment to describe this change

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a pull request use `#pull-request-id`
To close/fix an issue use `Closes #issue-id` or `Fixes #issue-id` (depending on the pull request)
-->
